### PR TITLE
lua-lsm: make lvm pool size configurable

### DIFF
--- a/security/lua/docs/USAGE.md
+++ b/security/lua/docs/USAGE.md
@@ -41,6 +41,24 @@ Check version:
 cat /sys/kernel/security/lua/version
 ```
 
+## Boot-time tuning
+
+The per-CPU Lua VM pool size is controlled by the kernel command line
+parameter `lua.lvm_pool_max=`. The default is `8`.
+
+Examples:
+
+```
+lua.lvm_pool_max=64
+lua.lvm_pool_max=0
+```
+
+Notes:
+
+- `0` disables returning Lua VMs to the per-CPU pool.
+- The current implementation accepts decimal values in the range `0..256`.
+- This is a boot-time setting only; there is no runtime knob in securityfs.
+
 ## Permissions
 
 Loading and unloading modules requires `CAP_MAC_ADMIN`.

--- a/security/lua/docs/USAGE.md
+++ b/security/lua/docs/USAGE.md
@@ -44,7 +44,7 @@ cat /sys/kernel/security/lua/version
 ## Boot-time tuning
 
 The per-CPU Lua VM pool size is controlled by the kernel command line
-parameter `lua.lvm_pool_max=`. The default is `8`.
+parameter `lua.lvm_pool_max=`. The default is `32`.
 
 Examples:
 

--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -10,6 +10,7 @@
 #include "debug.h"
 #include <linux/init.h>
 #include <linux/bitops.h>
+#include <linux/kstrtox.h>
 #include <linux/slab.h>
 #include <linux/string.h>
 #include <linux/printk.h>
@@ -263,7 +264,36 @@ static DEFINE_PER_CPU(struct lvm_state *, irq_lvms);
 static int lua_state_alloc(struct lvm_state *lvm);
 static void lua_state_free(struct lvm_state *lvm);
 
-#define LVM_POOL_MAX	8
+#define LUA_LVM_POOL_MAX_DEFAULT	8
+#define LUA_LVM_POOL_MAX_LIMIT		256
+
+static unsigned int lua_lvm_pool_max __read_mostly = LUA_LVM_POOL_MAX_DEFAULT;
+
+static int __init lua_lvm_pool_max_setup(char *str)
+{
+	unsigned int val;
+	int err;
+
+	if (!str || !*str)
+		return 1;
+
+	err = kstrtouint(str, 10, &val);
+	if (err) {
+		pr_warn("invalid lua.lvm_pool_max='%s', keeping %u\n",
+			str, lua_lvm_pool_max);
+		return 1;
+	}
+
+	if (val > LUA_LVM_POOL_MAX_LIMIT) {
+		pr_warn("lua.lvm_pool_max=%u exceeds limit %u, keeping %u\n",
+			val, LUA_LVM_POOL_MAX_LIMIT, lua_lvm_pool_max);
+		return 1;
+	}
+
+	WRITE_ONCE(lua_lvm_pool_max, val);
+	return 1;
+}
+__setup("lua.lvm_pool_max=", lua_lvm_pool_max_setup);
 
 struct lvm_pool_cpu {
 	struct lvm_state *head;
@@ -318,7 +348,7 @@ static void lvm_pool_put(struct lvm_state *lvm)
 	cpu = get_cpu();
 	pool = &per_cpu(lvm_pools, cpu);
 	raw_spin_lock_irqsave(&pool->lock, flags);
-	if (pool->count < LVM_POOL_MAX) {
+	if (pool->count < READ_ONCE(lua_lvm_pool_max)) {
 		lvm->next = pool->head;
 		pool->head = lvm;
 		pool->count++;
@@ -1386,7 +1416,8 @@ static int __init lua_lsm_init(void)
 	/* Report that Lua-LSM successfully initialized */
 	lua_lsm_initialized = 1;
 
-	pr_info("Lua based LSM initialized\n");
+	pr_info("Lua based LSM initialized (lvm_pool_max=%u)\n",
+		READ_ONCE(lua_lvm_pool_max));
 	return 0;
 }
 

--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -264,7 +264,7 @@ static DEFINE_PER_CPU(struct lvm_state *, irq_lvms);
 static int lua_state_alloc(struct lvm_state *lvm);
 static void lua_state_free(struct lvm_state *lvm);
 
-#define LUA_LVM_POOL_MAX_DEFAULT	8
+#define LUA_LVM_POOL_MAX_DEFAULT	32
 #define LUA_LVM_POOL_MAX_LIMIT		256
 
 static unsigned int lua_lvm_pool_max __read_mostly = LUA_LVM_POOL_MAX_DEFAULT;


### PR DESCRIPTION
This series does three things:

- make the per-CPU Lua VM pool size configurable via the kernel cmdline parameter `lua.lvm_pool_max=`
- document the cmdline parameter and clarify that it accepts decimal values in the range 0..256
- raise the default pool size from 8 to 32 in a separate commit

The default bump is intentional. The previous hard-coded default of 8 showed measurable performance drawbacks in benchmarks such as UnixBench, so the series keeps the configurability change and the default change separate.

Branch summary:
- 9849a01b6dc4 lua-lsm: make lvm pool size configurable
- 6b2264e7751e docs: document Lua-LSM lvm pool cmdline
- 807c8f9a1b19 lua-lsm: set default lvm pool size to 32
