### PR TITLE
 lua-lsm: narrow some supported hook surface

### DIFF
--- a/security/lua/docs/API.md
+++ b/security/lua/docs/API.md
@@ -11,7 +11,11 @@ Required fields:
 - `license` (string)
 - `version` (number)
 
-Hook functions are keyed by the LSM hook name (e.g. `file_open`).
+Hook functions are keyed by the supported LSM hook name (e.g. `file_open`).
+Use `kernel.lsm_funcs()` to enumerate the supported set. Lua-LSM does not
+expose unsupported hooks through its module APIs or observability output;
+the current unsupported set includes `getprocattr`, `setprocattr`, and
+`lsmprop_to_secctx`.
 
 Example:
 
@@ -59,6 +63,8 @@ From userspace (if stats enabled):
 ```
 cat /sys/kernel/security/lua/lsm_funcs
 ```
+
+Both interfaces list only hooks that Lua-LSM actually supports and registers.
 
 ## Built-in libraries
 

--- a/security/lua/docs/OBSERVABILITY.md
+++ b/security/lua/docs/OBSERVABILITY.md
@@ -28,7 +28,7 @@ cat /sys/kernel/security/lua/lsm_funcs
 ```
 
 Output columns:
-- `name`: LSM hook name
+- `name`: supported Lua-LSM hook name
 - `nlsm`: number of modules implementing the hook
 - `count`: invocation count
 - `total`: total time (ns)

--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -199,6 +199,7 @@ void lvm_stats_show(struct seq_file *m)
 int lsm_funcs_show(struct seq_file *m, void *v)
 {
 	int i;
+	int n = 0;
 	int cpu;
 
 	seq_printf(m, "stats for lua-lsm (ns)\n");
@@ -210,6 +211,9 @@ int lsm_funcs_show(struct seq_file *m, void *v)
 		u64 count = 0;
 		u64 total = 0;
 		u64 maxtime = 0;
+
+		if (!lua_lsm_hook_supported(i))
+			continue;
 
 		for_each_possible_cpu(cpu) {
 			const struct lua_lsm_hook_pcpu_stat *stat;
@@ -231,7 +235,7 @@ int lsm_funcs_show(struct seq_file *m, void *v)
 		}
 
 		seq_printf(m, "%3d %-28s %4d %12llu %15llu %10llu %12llu\n",
-			   i + 1, lua_lsm_hook_stats[i].name,
+			   ++n, lua_lsm_hook_stats[i].name,
 			   atomic_read(&lua_lsm_hook_stats[i].nhooks),
 			   count, total, count ? total / count : 0, maxtime);
 	}
@@ -939,6 +943,13 @@ int lua_lsm_module_register(const char *code, size_t len)
 			for (i = 0; lua_lsm_hook_stats[i].name; i++) {
 				if (strcmp(lua_lsm_hook_stats[i].name, key) != 0)
 					continue;
+
+				if (!lua_lsm_hook_supported(i)) {
+					__log_err("hook '%s' is not supported by Lua-LSM\n",
+						  key);
+					err = -EOPNOTSUPP;
+					goto err_free_module;
+				}
 
 				if (!lua_isfunction(L, -1)) {
 					__log_err("field '%s' must be a function\n", key);

--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -1386,6 +1386,7 @@ static int __init lua_lsm_init(void)
 	struct lvm_state *lvm;
 	int cpu;
 	int err;
+	int i;
 
 	for_each_possible_cpu(cpu)
 		lvm_pool_init_cpu(cpu);
@@ -1411,7 +1412,12 @@ static int __init lua_lsm_init(void)
 		per_cpu(irq_lvms, cpu) = lvm;
 	}
 
-	security_add_hooks(lua_lsm_hooks, ARRAY_SIZE(lua_lsm_hooks), &lua_lsmid);
+	/* Register only the hooks that Lua-LSM exposes to modules. */
+	for (i = 0; i < ARRAY_SIZE(lua_lsm_hooks); i++) {
+		if (!lua_lsm_hook_supported(i))
+			continue;
+		security_add_hooks(&lua_lsm_hooks[i], 1, &lua_lsmid);
+	}
 
 	/* Report that Lua-LSM successfully initialized */
 	lua_lsm_initialized = 1;

--- a/security/lua/lsm.h
+++ b/security/lua/lsm.h
@@ -52,6 +52,7 @@ static inline bool lua_lsm_hook_supported(unsigned int nr)
 	switch (nr) {
 	case __LL_NR_getprocattr:
 	case __LL_NR_setprocattr:
+	case __LL_NR_lsmprop_to_secctx:
 		return false;
 	default:
 		return nr < __LL_NR_MAX;

--- a/security/lua/lsm.h
+++ b/security/lua/lsm.h
@@ -47,6 +47,17 @@ enum {
 	__LL_NR_MAX
 };
 
+static inline bool lua_lsm_hook_supported(unsigned int nr)
+{
+	switch (nr) {
+	case __LL_NR_getprocattr:
+	case __LL_NR_setprocattr:
+		return false;
+	default:
+		return nr < __LL_NR_MAX;
+	}
+}
+
 struct lua_lsm_module_shdict {
 	struct list_head list;
 	struct kvcache_dict dict;

--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -2419,10 +2419,7 @@ LUA_LSM_INT_DEFINE4(setselfattr, unsigned int, attr, struct lsm_ctx *, ctx,
 	lua_pushinteger(L, (lua_Integer)flags);
 }
 
-/**
- * TODO: getprocattr
- * Default: -EINVAL
- */
+/* Not registered by Lua-LSM. */
 LUA_LSM_INT_DEFINE3(getprocattr, struct task_struct *, p,
 		const char *, name, char **, value)
 {
@@ -2431,10 +2428,6 @@ LUA_LSM_INT_DEFINE3(getprocattr, struct task_struct *, p,
 	lua_pushnil(L);	/* TODO: value */
 }
 
-/**
- * setprocattr
- * Default: -EINVAL
- */
 LUA_LSM_INT_DEFINE3(setprocattr, const char *, name,
 		void *, value, size_t, size)
 {

--- a/security/lua/lua_kernel.c
+++ b/security/lua/lua_kernel.c
@@ -411,9 +411,19 @@ static int kernel_lsm_funcs(lua_State *L)
 		#undef LSM_HOOK
 	};
 	int i;
+	int n = 0;
 
-	lua_createtable(L, ARRAY_SIZE(lsm_funcs), 0);
 	for (i = 0; i < ARRAY_SIZE(lsm_funcs); i++) {
+		if (lua_lsm_hook_supported(i))
+			n++;
+	}
+
+	lua_createtable(L, n, 0);
+	n = 0;
+	for (i = 0; i < ARRAY_SIZE(lsm_funcs); i++) {
+		if (!lua_lsm_hook_supported(i))
+			continue;
+
 		lua_createtable(L, 3, 0);
 		lua_pushstring(L, lsm_funcs[i].funcname);
 		lua_rawseti(L, -2, 1);
@@ -421,8 +431,8 @@ static int kernel_lsm_funcs(lua_State *L)
 		lua_rawseti(L, -2, 2);
 		lua_pushinteger(L, lsm_funcs[i].nargs);
 		lua_rawseti(L, -2, 3);
-		/* res[i + 1] = { funcname, rtype, nargs } */
-		lua_rawseti(L, -2, i + 1);
+		/* res[n + 1] = { funcname, rtype, nargs } */
+		lua_rawseti(L, -2, ++n);
 	}
 	return 1;
 }


### PR DESCRIPTION
Lua-LSM currently registers a few hooks that it does not implement yet,
but which are not ordinary stackable permission hooks:

  - `getprocattr`
  - `setprocattr`
  - `lsmprop_to_secctx`

This series stops registering those hooks, hides them from Lua-LSM's
module/introspection interfaces, and updates the documentation to match
the supported hook surface.

  ## Rationale

`getprocattr` and `setprocattr` back the generic `/proc/<pid>/attr/*`
interface and use legacy single-owner dispatch semantics.

`lsmprop_to_secctx` is also not a neutral hook to expose without a real
implementation, since some audit paths may select the first registered
provider.

Lua-LSM still only has placeholder behavior for these hooks. When Lua is
ordered before SELinux, that is enough to route procattr/secctx-related
operations to Lua-LSM first, where they fail before SELinux is reached.

The right behavior for now is simply not to claim these hooks until
Lua-LSM has a complete semantic implementation for them.

## This series

  1. Stop registering the legacy procattr hooks
  2. Stop registering `lsmprop_to_secctx`
  3. Hide unsupported hooks from module loading and introspection
  4. Update the docs to describe the supported hook surface