### PR TITLE
lua-lsm: fix hook marshalling and module lifetime bugs

### DIFF
--- a/security/lua/kvcache.c
+++ b/security/lua/kvcache.c
@@ -477,6 +477,30 @@ void kvcache_dict_init(struct kvcache_dict *dict)
 	dict->capacity = CACHE_CAPACITY;
 }
 
+static void lua_lsm_shdict_free_rcu(struct rcu_head *head)
+{
+	struct lua_lsm_module_shdict *shdict;
+
+	shdict = container_of(head, struct lua_lsm_module_shdict, rcu);
+	kvcache_dict_free(&shdict->dict);
+	kfree(shdict);
+}
+
+void lua_lsm_shdict_get(struct lua_lsm_module_shdict *shdict)
+{
+	if (shdict)
+		refcount_acquire(&shdict->refcount);
+}
+
+void lua_lsm_shdict_put(struct lua_lsm_module_shdict *shdict)
+{
+	if (!shdict)
+		return;
+
+	if (refcount_release(&shdict->refcount) == 0)
+		call_rcu(&shdict->rcu, lua_lsm_shdict_free_rcu);
+}
+
 /******************************** object cache *******************************/
 
 const int _module_sentinel;
@@ -595,28 +619,37 @@ int lua_object_newindex(lua_State *L, struct kvcache_dict *dict)
 
 static int shdict_set(lua_State *L)
 {
-	struct kvcache_dict *shdict = toshdict(L, 1);
+	struct lua_lsm_module_shdict *shdict = toshdict(L, 1);
 
-	return kvcache_set(L, shdict, NULL);
+	if (READ_ONCE(shdict->dead))
+		return kvcache_result(L, -ESRCH);
+
+	return kvcache_set(L, &shdict->dict, NULL);
 }
 
 static int shdict_get(lua_State *L)
 {
-	struct kvcache_dict *shdict = toshdict(L, 1);
+	struct lua_lsm_module_shdict *shdict = toshdict(L, 1);
 
-	return kvcache_get(L, shdict, NULL);
+	if (READ_ONCE(shdict->dead))
+		return kvcache_result(L, -ESRCH);
+
+	return kvcache_get(L, &shdict->dict, NULL);
 }
 
 static int shdict_incr(lua_State *L)
 {
-	struct kvcache_dict *shdict = toshdict(L, 1);
+	struct lua_lsm_module_shdict *shdict = toshdict(L, 1);
 
-	return kvcache_incr(L, shdict, NULL);
+	if (READ_ONCE(shdict->dead))
+		return kvcache_result(L, -ESRCH);
+
+	return kvcache_incr(L, &shdict->dict, NULL);
 }
 
 static int shdict_index(lua_State *L)
 {
-	struct kvcache_dict *shdict = toshdict(L, 1);
+	struct lua_lsm_module_shdict *shdict = toshdict(L, 1);
 
 	/* metatable[key] */
 	if (lua_getmetatable(L, 1) == 0) {
@@ -628,24 +661,33 @@ static int shdict_index(lua_State *L)
 	if (!lua_isnoneornil(L, -1))
 		return 1;
 
-	return kvcache_get(L, shdict, NULL);
+	if (READ_ONCE(shdict->dead))
+		return kvcache_result(L, -ESRCH);
+
+	return kvcache_get(L, &shdict->dict, NULL);
 }
 
 static int shdict_tostring(lua_State *L)
 {
-	struct kvcache_dict *shdict = toshdict(L, 1);
+	struct lua_lsm_module_shdict *shdict = toshdict(L, 1);
 	unsigned long flags;
 
-	read_lock_irqsave(&shdict->lock, flags);
+	if (READ_ONCE(shdict->dead)) {
+		lua_pushliteral(L, "shdict (dead)");
+		return 1;
+	}
+
+	read_lock_irqsave(&shdict->dict.lock, flags);
 	lua_pushfstring(L, "shdict (%d / %d)",
-			atomic_read(&shdict->count), shdict->capacity);
-	read_unlock_irqrestore(&shdict->lock, flags);
+			atomic_read(&shdict->dict.count),
+			shdict->dict.capacity);
+	read_unlock_irqrestore(&shdict->dict.lock, flags);
 	return 1;
 }
 
 static int shdict_gc(lua_State *L)
 {
-	__log_info_ratelimited("shdict already freed by unregister\n");
+	lua_lsm_shdict_put(toshdict(L, 1));
 	return 0;
 }
 

--- a/security/lua/kvcache.h
+++ b/security/lua/kvcache.h
@@ -19,6 +19,7 @@
 #define CACHE_CAPACITY	1024
 
 struct lua_lsm_module;
+struct lua_lsm_module_shdict;
 
 struct kvcache_node {
 	const char *key;
@@ -67,11 +68,15 @@ int lua_object_newindex(lua_State *L, struct kvcache_dict *dict);
 #define METH_SHARED_DICT	"meth_shared_dict"
 
 #define newshdict(L)							\
-	((struct kvcache_dict **)newcptr((L), METH_SHARED_DICT))
+	((struct lua_lsm_module_shdict **)				\
+		newcptr((L), METH_SHARED_DICT))
 #define toshdictp(L, idx)						\
-	((struct kvcache_dict **)luaL_checkudata((L), (idx), METH_SHARED_DICT))
+	((struct lua_lsm_module_shdict **)				\
+		luaL_checkudata((L), (idx), METH_SHARED_DICT))
 #define toshdict(L, idx)	(*toshdictp(L, idx))
 
+void lua_lsm_shdict_get(struct lua_lsm_module_shdict *shdict);
+void lua_lsm_shdict_put(struct lua_lsm_module_shdict *shdict);
 int shdict_init(lua_State *L);
 
 #endif  /* ! _SECURITY_LUA_LSM_KVCACHE_H */

--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -1267,6 +1267,7 @@ int lua_lsm_module_unregister(const char *name)
 
 	if (atomic_sub_return(count, &module->nloaded) == 0) {
 		list_del_rcu(&module->list);
+		synchronize_srcu(&modules_ss);
 		lua_lsm_module_free(module);
 		err = 0;
 	} else {

--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -272,6 +272,7 @@ static void lua_state_free(struct lvm_state *lvm);
 #define LUA_LVM_POOL_MAX_LIMIT		256
 
 static unsigned int lua_lvm_pool_max __read_mostly = LUA_LVM_POOL_MAX_DEFAULT;
+static atomic_t modules_unloading = ATOMIC_INIT(0);
 
 static int __init lua_lvm_pool_max_setup(char *str)
 {
@@ -423,6 +424,81 @@ static void lvm_vm_reset(struct lvm_state *lvm)
 	lua_gc(L, LUA_GCCOLLECT, 0);
 }
 
+static int lvm_remove_module(lua_State *L, struct lua_lsm_module *module)
+{
+	int err = -ENOENT;
+	int modules_idx;
+
+	/* registry._MODULES[modname] = nil */
+	lua_getfield(L, LUA_REGISTRYINDEX, "_MODULES");
+	if (lua_istable(L, -1)) {
+		modules_idx = lua_gettop(L);
+		lua_pushstring(L, module->name);
+		lua_rawget(L, modules_idx);
+		if (lua_istable(L, -1)) {
+			lua_pop(L, 1);
+
+			lua_pushstring(L, module->name);
+			lua_pushnil(L);
+			lua_rawset(L, modules_idx);
+
+			lua_getfield(L, LUA_REGISTRYINDEX, "_LOADED");
+			if (lua_istable(L, -1)) {
+				lua_pushstring(L, module->name);
+				lua_pushnil(L);
+				lua_rawset(L, -3);
+			}
+			lua_pop(L, 1);
+
+			/* performs a full garbage-collection cycle. */
+			lua_gc(L, LUA_GCCOLLECT, 0);
+			err = 0;
+		} else {
+			lua_pop(L, 1);
+		}
+	}
+	lua_pop(L, 1);
+	return err;
+}
+
+static int lvm_purge_module(lua_State *L, struct lua_lsm_module *module)
+{
+	int nloaded;
+	int err;
+
+	if (!module)
+		return -ENOENT;
+
+	err = lvm_remove_module(L, module);
+	if (!err) {
+		nloaded = atomic_dec_return(&module->nloaded);
+		WARN_ON_ONCE(nloaded < 0);
+
+		__log_info("<%s>: %d-%d purged module <%s>, nloaded = %d\n",
+			   current->comm, task_tgid_nr(current),
+			   task_pid_nr(current), module->name, nloaded);
+	}
+	return err;
+}
+
+static void lvm_purge_unloading(lua_State *L)
+{
+	struct lua_lsm_module *module;
+	int idx;
+
+	if (atomic_read(&modules_unloading) == 0)
+		return;
+
+	idx = srcu_read_lock(&modules_ss);
+	list_for_each_entry_srcu(module, &lsm_modules, list,
+				 srcu_read_lock_held(&modules_ss)) {
+		if (READ_ONCE(module->state) == LMS_STATE_GOING ||
+		    READ_ONCE(module->state) == LMS_STATE_ZOMBIE)
+			lvm_purge_module(L, module);
+	}
+	srcu_read_unlock(&modules_ss, idx);
+}
+
 static lua_State *
 lvm_get_from_task(const struct task_struct *task, bool exclusive)
 {
@@ -453,12 +529,17 @@ static void lvm_put_to_task(const struct task_struct *task, lua_State *L)
 
 lua_State *lvm_get(void)
 {
+	lua_State *L;
+
 	BUG_ON(in_nmi() || in_hardirq());
 
-	if (in_task())
-		return lvm_get_from_task(current, false);
-	else
+	if (in_task()) {
+		L = lvm_get_from_task(current, false);
+		lvm_purge_unloading(L);
+		return L;
+	} else {
 		return get_cpu_var(irq_lvms)->L;
+	}
 }
 
 void lvm_put(lua_State *L)
@@ -906,7 +987,7 @@ int lua_lsm_module_register(const char *code, size_t len)
 	if (!module)
 		goto err_free_lua;
 
-	module->state = LMS_STATE_COMING;
+	WRITE_ONCE(module->state, LMS_STATE_COMING);
 	__BITMAP_ZERO(&module->hookfuncs);
 
 	/* traversal the result table */
@@ -1024,6 +1105,7 @@ int lua_lsm_module_register(const char *code, size_t len)
 		goto err_free_module;
 	memcpy(module->chunk, chunk, chunk_len);
 	module->chunk_len = chunk_len;
+	atomic_set(&module->nloaded, 0);
 
 	INIT_LIST_HEAD(&module->shdicts);
 	spin_lock_init(&module->shdict_lock);
@@ -1046,7 +1128,7 @@ int lua_lsm_module_register(const char *code, size_t len)
 				atomic_inc(&lua_lsm_hook_stats[i].nhooks);
 		}
 
-		module->state = LMS_STATE_LIVE;
+		WRITE_ONCE(module->state, LMS_STATE_LIVE);
 		list_add_tail_rcu(&module->list, &lsm_modules);
 	}
 	mutex_unlock(&modules_mutex);
@@ -1071,85 +1153,6 @@ err_free_lua:
 	return err;
 }
 
-static int lvm_remove_module(lua_State *L, struct lua_lsm_module *module)
-{
-	int err = -ENOENT;
-	/* registry._MODULES[modname] = nil */
-	lua_getfield(L, LUA_REGISTRYINDEX, "_MODULES");
-	if (lua_istable(L, -1)) {
-		lua_pushstring(L, module->name);
-		lua_rawget(L, -2);
-		if (lua_istable(L, -1)) {
-			lua_pop(L, 1);
-
-			lua_pushstring(L, module->name);
-			lua_pushnil(L);
-			lua_rawset(L, -3);
-
-			/* performs a full garbage-collection cycle. */
-			lua_gc(L, LUA_GCCOLLECT, 0);
-			err = 0;
-		} else {
-			lua_pop(L, 1);
-		}
-	}
-	lua_pop(L, 1);
-	return err;
-}
-
-static int task_remove_module(struct task_struct *task, void *arg)
-{
-	struct lua_lsm_module *module = arg;
-	lua_State *L;
-	int err;
-
-	if (task_curr(task) && task != current)
-		return -EBUSY;
-
-	L = lvm_get_from_task(task, true);
-	if (!L)
-		return -EAGAIN;
-
-	err = lvm_remove_module(L, module);
-	lvm_put_to_task(task, L);
-	return err;
-}
-
-static int tasks_lvm_remove_module(struct lua_lsm_module *module, int *nbusy)
-{
-	struct task_struct *g, *task;
-	int count = 0;
-	int err;
-
-	*nbusy = 0;
-	/* remove loaded module from every Lua VM */
-	read_lock(&tasklist_lock);
-	for_each_process_thread(g, task) {
-		if (task == current)
-			err = task_remove_module(task, module);
-		else
-			err = task_call_func(task, task_remove_module, module);
-
-		if (!err) {
-			count++;
-			__log_info("<%s>: err = [ OK ] \t<%s>: %d-%d\n", module->name,
-				   task->comm, task_tgid_nr(task), task_pid_nr(task));
-		} else if (err == -EBUSY || err == -EAGAIN) {
-			*nbusy += 1;
-			__log_info("<%s>: err = %s \t<%s>: %d-%d\n",
-				   module->name, err == -EBUSY ? "EBUSY" : "EAGAIN",
-				   task->comm, task_tgid_nr(task), task_pid_nr(task));
-		} else {
-			__log_info_ratelimited("<%s>: err = %s \t<%s>: %d-%d\n",
-					       module->name,
-					       err == -ENOENT ? "[ENOENT]" : "unknown",
-					       task->comm, task_tgid_nr(task), task_pid_nr(task));
-		}
-	}
-	read_unlock(&tasklist_lock);
-	return count;
-}
-
 /*
  * Due to the limitations of schedule_on_each_cpu(), global variables
  * are used to pass parameters to the callback function.
@@ -1169,7 +1172,7 @@ static void softirq_lvm_remove_module(struct work_struct *work)
 	 * changing the Lua VM environment.
 	 */
 	local_bh_disable();
-	err = lvm_remove_module(per_cpu(irq_lvms, cpu)->L, module);
+	err = lvm_purge_module(per_cpu(irq_lvms, cpu)->L, module);
 	if (!err) {
 		atomic_inc(&work_ctx_remove_count);
 		__log_info("<%s>: err = [ OK ] \t<softirq-%d>, count = %d\n",
@@ -1178,16 +1181,50 @@ static void softirq_lvm_remove_module(struct work_struct *work)
 	local_bh_enable();
 }
 
+static void lua_lsm_module_unlink_shdicts(struct lua_lsm_module *module)
+{
+	struct lua_lsm_module_shdict *shdict, *tmp;
+	unsigned long flags;
+
+	spin_lock_irqsave(&module->shdict_lock, flags);
+	list_for_each_entry_safe(shdict, tmp, &module->shdicts, list) {
+		list_del_rcu(&shdict->list);
+		atomic_dec(&module->shdict_count);
+		lua_lsm_shdict_put(shdict);
+	}
+	spin_unlock_irqrestore(&module->shdict_lock, flags);
+}
+
+static void lua_lsm_module_disable_hooks(struct lua_lsm_module *module)
+{
+	int i;
+
+	for (i = 0; lua_lsm_hook_stats[i].name; i++) {
+		if (__BITMAP_ISSET(i, &module->hookfuncs))
+			atomic_dec(&lua_lsm_hook_stats[i].nhooks);
+	}
+}
+
+static void lua_lsm_module_finish_unregister(struct lua_lsm_module *module)
+{
+	WARN_ON_ONCE(atomic_read(&module->nloaded) != 0);
+
+	lua_lsm_module_disable_hooks(module);
+	list_del_rcu(&module->list);
+	lua_lsm_module_unlink_shdicts(module);
+	synchronize_srcu(&modules_ss);
+	lua_lsm_module_free(module);
+	atomic_dec(&modules_unloading);
+}
+
 int lua_lsm_module_unregister(const char *name)
 {
 	struct lua_lsm_module *module;
-	struct lua_lsm_module_shdict *shdict, *tmp;
-	int count = 0, nloaded, nbusy;
+	struct lua_lsm_module_shdict *shdict;
+	int count = 0, nloaded, remaining;
 	unsigned long flags;
-	unsigned int cpu;
 	int found = 0;
 	int err;
-	int i;
 
 	mutex_lock(&modules_mutex);
 	list_for_each_entry(module, &lsm_modules, list) {
@@ -1196,18 +1233,25 @@ int lua_lsm_module_unregister(const char *name)
 			break;
 		}
 	}
-	if (found && module->state == LMS_STATE_LIVE) {
-		module->state = LMS_STATE_GOING;
-
-		for (i = 0; lua_lsm_hook_stats[i].name; i++) {
-			if (__BITMAP_ISSET(i, &module->hookfuncs))
-				atomic_dec(&lua_lsm_hook_stats[i].nhooks);
-		}
+	if (found && READ_ONCE(module->state) == LMS_STATE_LIVE) {
+		/*
+		 * Keep the hook counts until final removal so tasks keep
+		 * entering Lua-LSM and can purge their own VMs.
+		 */
+		WRITE_ONCE(module->state, LMS_STATE_GOING);
+		atomic_inc(&modules_unloading);
 	}
 
 	if (!found) {
 		mutex_unlock(&modules_mutex);
 		return -ENOENT;
+	}
+
+	if (READ_ONCE(module->state) == LMS_STATE_ZOMBIE &&
+	    atomic_read(&module->nloaded) == 0) {
+		lua_lsm_module_finish_unregister(module);
+		mutex_unlock(&modules_mutex);
+		return 0;
 	}
 
 	pr_info("Prepare to unregister module <%s> ...\n", name);
@@ -1227,12 +1271,18 @@ int lua_lsm_module_unregister(const char *name)
 	kvcache_module_nodes_gc(module);
 
 	nloaded = atomic_read(&module->nloaded);
-	/* remove loaded module from every Lua VM */
 	if (nloaded > 0) {
-		count += tasks_lvm_remove_module(module, &nbusy);
+		lua_State *L = lvm_get_from_task(current, true);
 
-		__log_info("Unregister module <%s> from task, freed = %d/%d, nbusy = %d\n",
-			   name, count, nloaded, nbusy);
+		if (L) {
+			err = lvm_purge_module(L, module);
+			lvm_put_to_task(current, L);
+			if (!err)
+				count++;
+		}
+
+		__log_info("Unregister module <%s> from current task, freed = %d/%d\n",
+			   name, count, nloaded);
 	}
 
 	/*
@@ -1240,7 +1290,7 @@ int lua_lsm_module_unregister(const char *name)
 	 * so the nloaded will be updated in the air.
 	 */
 	nloaded = atomic_read(&module->nloaded);
-	if (count < nloaded) {
+	if (nloaded > 0) {
 		/*
 		 * Since global variables are used, locking ensures that only
 		 * one instance of the softirq LuaVM offload is executed.
@@ -1256,63 +1306,18 @@ int lua_lsm_module_unregister(const char *name)
 			   name, count, nloaded);
 	}
 
-	nloaded = atomic_read(&module->nloaded);
-	if (count < nloaded) {
-		/* ditto for the idle 'swapper' tasks */
-		cpus_read_lock();
-		for_each_possible_cpu(cpu) {
-			/* TODO: remove 'swapper' tasks Lua VM */
-			err = task_call_func(idle_task(cpu), task_remove_module, module);
-			if (!err)
-				count++;
-		}
-		cpus_read_unlock();
-
-		__log_info("Unregister module <%s> from swapper, freed = %d/%d\n",
-			   name, count, atomic_read(&module->nloaded));
-	}
-
-	nloaded = atomic_read(&module->nloaded);
-	if (count < nloaded && nbusy > 0) {
-		for (i = 1; i <= 5; i++) {
-			count += tasks_lvm_remove_module(module, &nbusy);
-			WARN_ON(count > nloaded);
-
-			__log_info("Unregister module <%s> from task, freed = %d/%d, nbusy = %d, loop = %d\n",
-				name, count, nloaded, nbusy, i);
-
-			nloaded = atomic_read(&module->nloaded);
-			if (count == nloaded || nbusy == 0)
-				break;
-
-			msleep(500 * i);
-
-			nloaded = atomic_read(&module->nloaded);
-			if (count == nloaded)
-				break;
-		}
-	}
-
-	if (atomic_sub_return(count, &module->nloaded) == 0) {
-		list_del_rcu(&module->list);
-		spin_lock_irqsave(&module->shdict_lock, flags);
-		list_for_each_entry_safe(shdict, tmp, &module->shdicts, list) {
-			list_del_rcu(&shdict->list);
-			atomic_dec(&module->shdict_count);
-			lua_lsm_shdict_put(shdict);
-		}
-		spin_unlock_irqrestore(&module->shdict_lock, flags);
-		synchronize_srcu(&modules_ss);
-		lua_lsm_module_free(module);
+	remaining = atomic_read(&module->nloaded);
+	if (remaining == 0) {
+		lua_lsm_module_finish_unregister(module);
 		err = 0;
 	} else {
-		module->state = LMS_STATE_ZOMBIE;
+		WRITE_ONCE(module->state, LMS_STATE_ZOMBIE);
 		err = -EBUSY;
 	}
 	mutex_unlock(&modules_mutex);
 
-	pr_info("Unregistered module <%s> from %d/%d Lua VMs, vm_nusage = %d\n",
-		name, count, nloaded, atomic_read(&vm_nusage));
+	pr_info("Unregister module <%s>: purged %d Lua VMs, remaining = %d, vm_nusage = %d\n",
+		name, count, remaining, atomic_read(&vm_nusage));
 
 	return err;
 }

--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -265,6 +265,15 @@ static inline void lvm_stats_memalloc(struct lvm_state *lvm, void *ptr,
 
 static DEFINE_PER_CPU(struct lvm_state *, irq_lvms);
 
+static void lua_lsm_module_queue_destroy(void);
+static void lua_lsm_module_retire_locked(struct lua_lsm_module *module);
+static void lua_lsm_module_destroy_workfn(struct work_struct *work);
+static DECLARE_WORK(lua_lsm_module_destroy_work,
+		    lua_lsm_module_destroy_workfn);
+static DEFINE_SPINLOCK(lua_lsm_module_destroy_lock);
+static bool lua_lsm_module_destroy_running;
+static bool lua_lsm_module_destroy_rescan;
+
 static int lua_state_alloc(struct lvm_state *lvm);
 static void lua_state_free(struct lvm_state *lvm);
 
@@ -473,12 +482,22 @@ static int lvm_purge_module(lua_State *L, struct lua_lsm_module *module)
 	if (!err) {
 		nloaded = atomic_dec_return(&module->nloaded);
 		WARN_ON_ONCE(nloaded < 0);
+		if (nloaded == 0 && READ_ONCE(module->state) == LMS_STATE_ZOMBIE)
+			lua_lsm_module_queue_destroy();
 
 		__log_info("<%s>: %d-%d purged module <%s>, nloaded = %d\n",
 			   current->comm, task_tgid_nr(current),
 			   task_pid_nr(current), module->name, nloaded);
 	}
 	return err;
+}
+
+static bool lvm_module_needs_purge(struct lua_lsm_module *module)
+{
+	enum lua_lsm_module_state state = READ_ONCE(module->state);
+
+	return atomic_read(&module->nloaded) > 0 &&
+	       (state == LMS_STATE_GOING || state == LMS_STATE_ZOMBIE);
 }
 
 static void lvm_purge_unloading(lua_State *L)
@@ -492,8 +511,7 @@ static void lvm_purge_unloading(lua_State *L)
 	idx = srcu_read_lock(&modules_ss);
 	list_for_each_entry_srcu(module, &lsm_modules, list,
 				 srcu_read_lock_held(&modules_ss)) {
-		if (READ_ONCE(module->state) == LMS_STATE_GOING ||
-		    READ_ONCE(module->state) == LMS_STATE_ZOMBIE)
+		if (lvm_module_needs_purge(module))
 			lvm_purge_module(L, module);
 	}
 	srcu_read_unlock(&modules_ss, idx);
@@ -772,6 +790,7 @@ static int lua_modules_index(lua_State *L)
 static void lua_modules_free(struct task_struct *task, lua_State *L)
 {
 	struct lua_lsm_module *module;
+	int nloaded;
 
 	lua_getfield(L, LUA_REGISTRYINDEX, "_MODULES");
 	if (!lua_istable(L, -1)) {
@@ -779,14 +798,18 @@ static void lua_modules_free(struct task_struct *task, lua_State *L)
 		return;
 	}
 
-	list_for_each_entry_srcu(module, &lsm_modules, list, srcu_read_lock_held(&modules_ss)) {
+	list_for_each_entry_srcu(module, &lsm_modules, list,
+				 srcu_read_lock_held(&modules_ss)) {
 		lua_pushstring(L, module->name);
 		lua_rawget(L, -2);
 		if (lua_istable(L, -1)) {
-			atomic_dec(&module->nloaded);
+			nloaded = atomic_dec_return(&module->nloaded);
+			WARN_ON_ONCE(nloaded < 0);
+			if (nloaded == 0 && READ_ONCE(module->state) == LMS_STATE_ZOMBIE)
+				lua_lsm_module_queue_destroy();
 			__log_info("<%s>: %d-%d freed module <%s>, nloaded = %d\n",
 				   task->comm, task_tgid_nr(task), task_pid_nr(task),
-				   module->name, atomic_read(&module->nloaded));
+				   module->name, nloaded);
 		}
 		lua_pop(L, 1);
 	}
@@ -1181,6 +1204,92 @@ static void softirq_lvm_remove_module(struct work_struct *work)
 	local_bh_enable();
 }
 
+/*
+ * Lazy VM teardown can drop the final module reference after unregister()
+ * already returned -EBUSY. Final removal must run outside SRCU read-side
+ * sections, so queue a worker to retry the last unregister step.  The
+ * worker detaches one drained zombie under modules_mutex, then waits for
+ * the SRCU grace period and frees it without holding the mutex.
+ */
+static bool lua_lsm_module_drained(struct lua_lsm_module *module)
+{
+	if (READ_ONCE(module->state) != LMS_STATE_ZOMBIE)
+		return false;
+	if (atomic_read(&module->nloaded) != 0)
+		return false;
+
+	return true;
+}
+
+static struct lua_lsm_module *lua_lsm_module_take_drained_locked(void)
+{
+	struct lua_lsm_module *module, *tmp;
+
+	list_for_each_entry_safe(module, tmp, &lsm_modules, list) {
+		if (!lua_lsm_module_drained(module))
+			continue;
+
+		lua_lsm_module_retire_locked(module);
+		return module;
+	}
+
+	return NULL;
+}
+
+static void lua_lsm_module_destroy(struct lua_lsm_module *module)
+{
+	synchronize_srcu(&modules_ss);
+	lua_lsm_module_free(module);
+}
+
+static void lua_lsm_module_queue_destroy(void)
+{
+	unsigned long flags;
+	bool queue = false;
+
+	spin_lock_irqsave(&lua_lsm_module_destroy_lock, flags);
+	lua_lsm_module_destroy_rescan = true;
+	if (!lua_lsm_module_destroy_running) {
+		lua_lsm_module_destroy_running = true;
+		queue = true;
+	}
+	spin_unlock_irqrestore(&lua_lsm_module_destroy_lock, flags);
+
+	if (queue)
+		schedule_work(&lua_lsm_module_destroy_work);
+}
+
+static void lua_lsm_module_destroy_workfn(struct work_struct *work)
+{
+	struct lua_lsm_module *module;
+	unsigned long flags;
+
+	for (;;) {
+		spin_lock_irqsave(&lua_lsm_module_destroy_lock, flags);
+		lua_lsm_module_destroy_rescan = false;
+		spin_unlock_irqrestore(&lua_lsm_module_destroy_lock, flags);
+
+		for (;;) {
+			mutex_lock(&modules_mutex);
+			module = lua_lsm_module_take_drained_locked();
+			mutex_unlock(&modules_mutex);
+
+			if (!module)
+				break;
+
+			lua_lsm_module_destroy(module);
+		}
+
+		spin_lock_irqsave(&lua_lsm_module_destroy_lock, flags);
+		if (!lua_lsm_module_destroy_rescan) {
+			lua_lsm_module_destroy_running = false;
+			spin_unlock_irqrestore(&lua_lsm_module_destroy_lock, flags);
+			break;
+		}
+		spin_unlock_irqrestore(&lua_lsm_module_destroy_lock, flags);
+	}
+}
+
 static void lua_lsm_module_unlink_shdicts(struct lua_lsm_module *module)
 {
 	struct lua_lsm_module_shdict *shdict, *tmp;
@@ -1205,21 +1314,22 @@ static void lua_lsm_module_disable_hooks(struct lua_lsm_module *module)
 	}
 }
 
-static void lua_lsm_module_finish_unregister(struct lua_lsm_module *module)
+static void lua_lsm_module_retire_locked(struct lua_lsm_module *module)
 {
 	WARN_ON_ONCE(atomic_read(&module->nloaded) != 0);
+	WARN_ON_ONCE(READ_ONCE(module->state) != LMS_STATE_GOING &&
+		     READ_ONCE(module->state) != LMS_STATE_ZOMBIE);
 
 	lua_lsm_module_disable_hooks(module);
 	list_del_rcu(&module->list);
 	lua_lsm_module_unlink_shdicts(module);
-	synchronize_srcu(&modules_ss);
-	lua_lsm_module_free(module);
 	atomic_dec(&modules_unloading);
 }
 
 int lua_lsm_module_unregister(const char *name)
 {
 	struct lua_lsm_module *module;
+	struct lua_lsm_module *retired = NULL;
 	struct lua_lsm_module_shdict *shdict;
 	int count = 0, nloaded, remaining;
 	unsigned long flags;
@@ -1247,12 +1357,8 @@ int lua_lsm_module_unregister(const char *name)
 		return -ENOENT;
 	}
 
-	if (READ_ONCE(module->state) == LMS_STATE_ZOMBIE &&
-	    atomic_read(&module->nloaded) == 0) {
-		lua_lsm_module_finish_unregister(module);
-		mutex_unlock(&modules_mutex);
-		return 0;
-	}
+	if (lua_lsm_module_drained(module))
+		goto out_detach;
 
 	pr_info("Prepare to unregister module <%s> ...\n", name);
 
@@ -1307,14 +1413,26 @@ int lua_lsm_module_unregister(const char *name)
 	}
 
 	remaining = atomic_read(&module->nloaded);
-	if (remaining == 0) {
-		lua_lsm_module_finish_unregister(module);
-		err = 0;
-	} else {
-		WRITE_ONCE(module->state, LMS_STATE_ZOMBIE);
-		err = -EBUSY;
-	}
+	if (remaining == 0)
+		goto out_detach;
+
+	WRITE_ONCE(module->state, LMS_STATE_ZOMBIE);
+	if (lua_lsm_module_drained(module))
+		goto out_detach;
+
+	remaining = atomic_read(&module->nloaded);
+	err = -EBUSY;
+	goto out_unlock;
+
+out_detach:
+	remaining = 0;
+	lua_lsm_module_retire_locked(module);
+	retired = module;
+	err = 0;
+out_unlock:
 	mutex_unlock(&modules_mutex);
+	if (retired)
+		lua_lsm_module_destroy(retired);
 
 	pr_info("Unregister module <%s>: purged %d Lua VMs, remaining = %d, vm_nusage = %d\n",
 		name, count, remaining, atomic_read(&vm_nusage));

--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -475,6 +475,7 @@ static int lua_shared_index(lua_State *L)
 {
 	const char *name = luaL_checkstring(L, 2);
 	struct lua_lsm_module_shdict *shdict = NULL, *new = NULL, *shtmp;
+	struct lua_lsm_module_shdict **slot;
 	struct lua_lsm_module *module;
 	unsigned long flags;
 	int found = 0;
@@ -493,6 +494,9 @@ static int lua_shared_index(lua_State *L)
 	if (READ_ONCE(module->state) != LMS_STATE_LIVE)
 		return 0;
 
+	lua_pushvalue(L, 2);
+	slot = newshdict(L);
+
 	spin_lock_irqsave(&module->shdict_lock, flags);
 	list_for_each_entry(shtmp, &module->shdicts, list) {
 		if (strcmp(shtmp->name, name) == 0) {
@@ -507,7 +511,7 @@ static int lua_shared_index(lua_State *L)
 	spin_unlock_irqrestore(&module->shdict_lock, flags);
 
 	if (found && !shdict)
-		return 0;
+		goto err_pop_userdata;
 
 	if (!shdict) {
 		size_t l = strlen(name);
@@ -515,7 +519,7 @@ static int lua_shared_index(lua_State *L)
 		new = kzalloc(struct_size(new, name, l + 1), lua_lsm_gfp());
 		if (!new) {
 			__log_err("No memory\n");
-			return 0;
+			goto err_pop_userdata;
 		}
 		refcount_init(&new->refcount, 1);
 		kvcache_dict_init(&new->dict);
@@ -547,16 +551,19 @@ static int lua_shared_index(lua_State *L)
 	}
 
 	if (!shdict)
-		return 0;
+		goto err_pop_userdata;
 
 	/* shared[name] = shdict */
-	lua_pushvalue(L, 2);
-	*newshdict(L) = shdict;
+	*slot = shdict;
 	lua_rawset(L, 1);
 
 	lua_settop(L, 2);
 	lua_rawget(L, 1);
 	return 1;
+
+err_pop_userdata:
+	lua_settop(L, 2);
+	return 0;
 }
 
 static int lua_shared_newindex(lua_State *L)

--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -474,8 +474,9 @@ void lvm_put(lua_State *L)
 static int lua_shared_index(lua_State *L)
 {
 	const char *name = luaL_checkstring(L, 2);
-	struct lua_lsm_module_shdict *shdict, *shtmp;
+	struct lua_lsm_module_shdict *shdict = NULL, *new = NULL, *shtmp;
 	struct lua_lsm_module *module;
+	unsigned long flags;
 	int found = 0;
 
 	__log_info_ratelimited("READ shared table, [%s] %s\n",
@@ -489,29 +490,37 @@ static int lua_shared_index(lua_State *L)
 		return 0;
 	}
 	module = lua_touserdata(L, -1);
+	if (READ_ONCE(module->state) != LMS_STATE_LIVE)
+		return 0;
 
-	rcu_read_lock();
-	list_for_each_entry_rcu(shdict, &module->shdicts, list) {
-		if (strcmp(shdict->name, name) == 0) {
+	spin_lock_irqsave(&module->shdict_lock, flags);
+	list_for_each_entry(shtmp, &module->shdicts, list) {
+		if (strcmp(shtmp->name, name) == 0) {
 			found = 1;
 			break;
 		}
 	}
-	rcu_read_unlock();
+	if (found && !READ_ONCE(shtmp->dead)) {
+		lua_lsm_shdict_get(shtmp);
+		shdict = shtmp;
+	}
+	spin_unlock_irqrestore(&module->shdict_lock, flags);
 
-	if (!found) {
-		unsigned long flags;
+	if (found && !shdict)
+		return 0;
+
+	if (!shdict) {
 		size_t l = strlen(name);
 
-		shdict = kmalloc(struct_size(shdict, name, l + 1),
-				 lua_lsm_gfp());
-		if (!shdict) {
+		new = kzalloc(struct_size(new, name, l + 1), lua_lsm_gfp());
+		if (!new) {
 			__log_err("No memory\n");
 			return 0;
 		}
-		kvcache_dict_init(&shdict->dict);
-		memcpy(shdict->name, name, l);
-		shdict->name[l] = '\0';
+		refcount_init(&new->refcount, 1);
+		kvcache_dict_init(&new->dict);
+		memcpy(new->name, name, l);
+		new->name[l] = '\0';
 
 		spin_lock_irqsave(&module->shdict_lock, flags);
 		list_for_each_entry(shtmp, &module->shdicts, list) {
@@ -520,23 +529,29 @@ static int lua_shared_index(lua_State *L)
 				break;
 			}
 		}
-		if (!found) {
+		if (found) {
+			if (!READ_ONCE(shtmp->dead)) {
+				lua_lsm_shdict_get(shtmp);
+				shdict = shtmp;
+			}
+		} else if (READ_ONCE(module->state) == LMS_STATE_LIVE) {
 			atomic_inc(&module->shdict_count);
-			list_add_tail_rcu(&shdict->list, &module->shdicts);
+			list_add_tail_rcu(&new->list, &module->shdicts);
+			lua_lsm_shdict_get(new);
+			shdict = new;
+			new = NULL;
 		}
 		spin_unlock_irqrestore(&module->shdict_lock, flags);
 
-		if (found) {
-			kvcache_dict_free(&shdict->dict);
-			kfree(shdict);
-
-			shdict = shtmp;
-		}
+		lua_lsm_shdict_put(new);
 	}
+
+	if (!shdict)
+		return 0;
 
 	/* shared[name] = shdict */
 	lua_pushvalue(L, 2);
-	*newshdict(L) = &shdict->dict;
+	*newshdict(L) = shdict;
 	lua_rawset(L, 1);
 
 	lua_settop(L, 2);
@@ -637,6 +652,8 @@ static int lua_modules_index(lua_State *L)
 	/* module queries are always run with a read lock */
 	list_for_each_entry_srcu(module, &lsm_modules, list,
 				 srcu_read_lock_held(&modules_ss)) {
+		if (READ_ONCE(module->state) != LMS_STATE_LIVE)
+			continue;
 		if (strcmp(module->name, key) != 0)
 			continue;
 
@@ -1159,6 +1176,7 @@ int lua_lsm_module_unregister(const char *name)
 	struct lua_lsm_module *module;
 	struct lua_lsm_module_shdict *shdict, *tmp;
 	int count = 0, nloaded, nbusy;
+	unsigned long flags;
 	unsigned int cpu;
 	int found = 0;
 	int err;
@@ -1189,12 +1207,15 @@ int lua_lsm_module_unregister(const char *name)
 
 	synchronize_srcu(&modules_ss);
 
-	list_for_each_entry_safe(shdict, tmp, &module->shdicts, list) {
-		list_del(&shdict->list);
-		kvcache_dict_free(&shdict->dict);
-		kfree(shdict);
-		atomic_dec(&module->shdict_count);
-	}
+	/*
+	 * Existing Lua userdata may outlive the VM purge attempt.  Tombstone
+	 * shared dicts now and drop the module list refs only once unregister
+	 * can complete.
+	 */
+	spin_lock_irqsave(&module->shdict_lock, flags);
+	list_for_each_entry(shdict, &module->shdicts, list)
+		WRITE_ONCE(shdict->dead, true);
+	spin_unlock_irqrestore(&module->shdict_lock, flags);
 
 	kvcache_module_nodes_gc(module);
 
@@ -1267,6 +1288,13 @@ int lua_lsm_module_unregister(const char *name)
 
 	if (atomic_sub_return(count, &module->nloaded) == 0) {
 		list_del_rcu(&module->list);
+		spin_lock_irqsave(&module->shdict_lock, flags);
+		list_for_each_entry_safe(shdict, tmp, &module->shdicts, list) {
+			list_del_rcu(&shdict->list);
+			atomic_dec(&module->shdict_count);
+			lua_lsm_shdict_put(shdict);
+		}
+		spin_unlock_irqrestore(&module->shdict_lock, flags);
 		synchronize_srcu(&modules_ss);
 		lua_lsm_module_free(module);
 		err = 0;

--- a/security/lua/lsm.h
+++ b/security/lua/lsm.h
@@ -9,6 +9,7 @@
 #define _SECURITY_LUA_LSM_LSM_H
 
 #include <linux/list.h>
+#include <linux/rcupdate.h>
 #include <linux/sched.h>
 #include <linux/fs.h>
 #include <linux/msg.h>
@@ -61,6 +62,10 @@ static inline bool lua_lsm_hook_supported(unsigned int nr)
 
 struct lua_lsm_module_shdict {
 	struct list_head list;
+	/* One ref for the module list, one per cached Lua userdata. */
+	atomic_t refcount;
+	struct rcu_head rcu;
+	bool dead;
 	struct kvcache_dict dict;
 	char name[];
 };

--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -1320,7 +1320,7 @@ LUA_LSM_INT_NAKED_DEFINE3(inode_listsecurity, struct inode *, inode,
 				const char *v = lua_tolstring(L, top, &len);
 				ret = (int)len;
 				if (buffer != NULL && len <= buffer_size)
-					memcpy(buffer, v, buffer_size);
+					memcpy(buffer, v, len);
 			}
 			break;
 		default:
@@ -1795,7 +1795,7 @@ LUA_LSM_INT_DEFINE2(kernel_load_data, enum kernel_load_data_id, id,
 LUA_LSM_INT_DEFINE4(kernel_post_load_data, char *, buf, loff_t, size,
 		enum kernel_load_data_id, id, char *, description)
 {
-	lua_pushstring(L, (const char *)buf);
+	lua_pushlstring(L, (const char *)buf, (size_t)size);
 	lua_pushinteger(L, (lua_Integer)size);
 	lua_pushnil(L);	/* TODO: id */
 	lua_pushstring(L, (const char *)description);
@@ -1821,7 +1821,7 @@ LUA_LSM_INT_DEFINE4(kernel_post_read_file, struct file *, file,
 		char *, buf, loff_t, size, enum kernel_read_file_id, id)
 {
 	*newfile(L) = file;
-	lua_pushstring(L, (const char *)buf);
+	lua_pushlstring(L, (const char *)buf, (size_t)size);
 	lua_pushinteger(L, (lua_Integer)size);
 	lua_pushnil(L);	/* TODO: id */
 }

--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -771,9 +771,16 @@ LUA_LSM_VOID_DEFINE1(inode_free_security_rcu, void *, inode_security)
 	lua_pushnil(L);	/* TODO: inode_security */
 }
 
-static int lua_lsm_check_xattr(const char *name, size_t name_len,
-			       size_t value_len)
+static int lua_lsm_init_xattr(lua_State *L, int name_idx, int value_idx,
+			      struct xattr *xattr)
 {
+	size_t name_len, value_len;
+	const char *name, *value;
+	char *buffer;
+
+	name = lua_tolstring(L, name_idx, &name_len);
+	value = lua_tolstring(L, value_idx, &value_len);
+
 	if (!name_len || name_len > XATTR_NAME_MAX - XATTR_SECURITY_PREFIX_LEN)
 		return -EINVAL;
 	if (memchr(name, '\0', name_len))
@@ -781,6 +788,18 @@ static int lua_lsm_check_xattr(const char *name, size_t name_len,
 	if (value_len > XATTR_SIZE_MAX)
 		return -E2BIG;
 
+	buffer = kmalloc(value_len + name_len + 1, GFP_NOFS);
+	if (!buffer)
+		return -ENOMEM;
+
+	memcpy(buffer, value, value_len);
+	memcpy(buffer + value_len, name, name_len);
+	buffer[value_len + name_len] = '\0';
+
+	/* security_inode_init_security() frees value but not name. */
+	xattr->value = buffer;
+	xattr->value_len = value_len;
+	xattr->name = buffer + value_len;
 	return 0;
 }
 
@@ -795,7 +814,7 @@ static int lua_lsm_check_xattr(const char *name, size_t name_len,
  *   false        : -EPERM
  *   false, errno : -errno
  *   nil, errno   : -errno
- *   name, value  : fill the xattr struct, XXX: name must not be freed
+ *   name, value  : fill the xattr struct
  */
 LUA_LSM_INT_NAKED_DEFINE5(inode_init_security, struct inode *, inode,
 		struct inode *, dir, const struct qstr *, qstr,
@@ -837,29 +856,10 @@ LUA_LSM_INT_NAKED_DEFINE5(inode_init_security, struct inode *, inode,
 				ret = -errno;
 		} else if (lua_isstring(L, top) && lua_isstring(L, top + 1)) {
 			struct xattr *xattr;
-			const char *name;
-			const char *value;
-			size_t name_len, len;
 
 			xattr = lsm_get_xattr_slot(xattrs, xattr_count);
-			if (xattr) {
-				name = lua_tolstring(L, top, &name_len);
-				value = lua_tolstring(L, top + 1, &len);
-				ret = lua_lsm_check_xattr(name, name_len, len);
-				if (ret)
-					break;
-
-				xattr->value = kmemdup(value, len, GFP_NOFS);
-				if (xattr->value == NULL) {
-					ret = -ENOMEM;
-					break;
-				}
-				xattr->value_len = len;
-				xattr->name = name;
-				ret = 0;
-			} else {
-				/* TODO */
-			}
+			if (xattr)
+				ret = lua_lsm_init_xattr(L, top, top + 1, xattr);
 		}
 		break;
 	}

--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -21,6 +21,7 @@
 #include <linux/syscalls.h>     /* for __MAP */
 #include <linux/timekeeping.h>  /* for ktime_get */
 #include <net/ipv6.h>
+#include <uapi/linux/un.h>
 #include <linux/lsm_hooks.h>
 #include <uapi/linux/lsm.h>
 #include <linux/lua.h>
@@ -2636,8 +2637,16 @@ static int build_sockaddr(lua_State *L, struct sockaddr *address, int addrlen)
 		if (addrlen < SIN6_LEN_RFC2133)
 			return 0;
 		break;
+	case AF_UNIX:
+		if (addrlen < offsetof(struct sockaddr_un, sun_path))
+			return 0;
+		break;
 	}
-	*newsockaddr(L) = address;
+	{
+		struct lua_sockaddr *p = newsockaddr(L);
+		p->addr = address;
+		p->addrlen = addrlen;
+	}
 	return 1;
 }
 

--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -796,7 +796,13 @@ static int lua_lsm_init_xattr(lua_State *L, int name_idx, int value_idx,
 	memcpy(buffer + value_len, name, name_len);
 	buffer[value_len + name_len] = '\0';
 
-	/* security_inode_init_security() frees value but not name. */
+	/*
+	 * FIXME: xattr->name must not share xattr->value storage. Some
+	 * initxattrs users, notably OCFS2, duplicate only value and keep
+	 * the name pointer after security_inode_init_security() frees value.
+	 * This needs separate name storage with a lifetime that covers those
+	 * delayed users.
+	 */
 	xattr->value = buffer;
 	xattr->value_len = value_len;
 	xattr->name = buffer + value_len;

--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -2658,7 +2658,8 @@ static int build_sockaddr(lua_State *L, struct sockaddr *address, int addrlen)
 			return 0;
 		break;
 	case AF_UNIX:
-		if (addrlen < offsetof(struct sockaddr_un, sun_path))
+		if (addrlen < offsetof(struct sockaddr_un, sun_path) ||
+		    addrlen > sizeof(struct sockaddr_un))
 			return 0;
 		break;
 	}

--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -16,6 +16,7 @@
 #include <linux/compiler.h>
 #include <linux/rwlock.h>
 #include <linux/security.h>
+#include <linux/xattr.h>
 #include <linux/cred.h>
 #include <linux/prctl.h>
 #include <linux/syscalls.h>     /* for __MAP */
@@ -770,6 +771,19 @@ LUA_LSM_VOID_DEFINE1(inode_free_security_rcu, void *, inode_security)
 	lua_pushnil(L);	/* TODO: inode_security */
 }
 
+static int lua_lsm_check_xattr(const char *name, size_t name_len,
+			       size_t value_len)
+{
+	if (!name_len || name_len > XATTR_NAME_MAX - XATTR_SECURITY_PREFIX_LEN)
+		return -EINVAL;
+	if (memchr(name, '\0', name_len))
+		return -EINVAL;
+	if (value_len > XATTR_SIZE_MAX)
+		return -E2BIG;
+
+	return 0;
+}
+
 /**
  * inode_init_security
  * Default: -EOPNOTSUPP
@@ -823,19 +837,25 @@ LUA_LSM_INT_NAKED_DEFINE5(inode_init_security, struct inode *, inode,
 				ret = -errno;
 		} else if (lua_isstring(L, top) && lua_isstring(L, top + 1)) {
 			struct xattr *xattr;
+			const char *name;
 			const char *value;
-			size_t len;
+			size_t name_len, len;
 
 			xattr = lsm_get_xattr_slot(xattrs, xattr_count);
 			if (xattr) {
+				name = lua_tolstring(L, top, &name_len);
 				value = lua_tolstring(L, top + 1, &len);
+				ret = lua_lsm_check_xattr(name, name_len, len);
+				if (ret)
+					break;
+
 				xattr->value = kmemdup(value, len, GFP_NOFS);
 				if (xattr->value == NULL) {
 					ret = -ENOMEM;
 					break;
 				}
 				xattr->value_len = len;
-				xattr->name = lua_tostring(L, top);
+				xattr->name = name;
 				ret = 0;
 			} else {
 				/* TODO */

--- a/security/lua/lsm_defs.h
+++ b/security/lua/lsm_defs.h
@@ -140,7 +140,7 @@
 					srcu_read_lock_held(&modules_ss)) {		\
 			if (!__BITMAP_ISSET(__LL_NR_ ## NAME, &module->hookfuncs))	\
 				continue;						\
-			if (module->state != LMS_STATE_LIVE)				\
+			if (READ_ONCE(module->state) != LMS_STATE_LIVE)			\
 				continue;						\
 			lua_getfield(L, -1, module->name);				\
 			lua_getfield(L, -1, #NAME);					\

--- a/security/lua/lua_fs.c
+++ b/security/lua/lua_fs.c
@@ -554,13 +554,15 @@ static int fs_filp_open(lua_State *L)
 	const char *filename = luaL_checkstring(L, 1);
 	int flags = luaL_checkinteger(L, 2);
 	umode_t mode = luaL_checkinteger(L, 3);
+	struct file *file;
 	struct file **filp = newgcfile(L);
-	*filp = filp_open(filename, flags, mode);
-	if (IS_ERR(*filp)) {
+	file = filp_open(filename, flags, mode);
+	if (IS_ERR(file)) {
 		lua_pushnil(L);
-		lua_pushinteger(L, PTR_ERR(*filp));
+		lua_pushinteger(L, PTR_ERR(file));
 		return 2;
 	}
+	*filp = file;
 	return 1;
 }
 

--- a/security/lua/lua_net.c
+++ b/security/lua/lua_net.c
@@ -7,6 +7,7 @@
 
 #include "debug.h"
 #include <linux/printk.h>
+#include <linux/string.h>
 #include <linux/security.h>
 #include <linux/inet.h>
 #include <net/inet_sock.h>
@@ -68,6 +69,30 @@ static const char *family_tostring(sa_family_t sa_family)
 	}
 
 	return family;
+}
+
+static size_t sockaddr_un_path_len(const struct sockaddr_un *sunaddr, int addrlen)
+{
+	int offset = offsetof(struct sockaddr_un, sun_path);
+	size_t path_len;
+
+	if (addrlen <= offset)
+		return 0;
+
+	path_len = addrlen - offset;
+
+	/*
+	 * Pathname sockets are C strings; abstract sockets keep their full
+	 * declared length, including embedded NUL bytes.
+	 */
+	if (sunaddr->sun_path[0] != '\0') {
+		const char *nul = memchr(sunaddr->sun_path, '\0', path_len);
+
+		if (nul)
+			path_len = nul - sunaddr->sun_path;
+	}
+
+	return path_len;
 }
 
 /*********************************** sock ***********************************/
@@ -360,10 +385,15 @@ static int sockaddr_addrs(lua_State *L)
 		}
 		lua_pushinteger(L, ntohs(((struct sockaddr_in6 *)sa)->sin6_port));
 		return 3;
-	case AF_UNIX:
+	case AF_UNIX: {
+		struct sockaddr_un *sunaddr = (struct sockaddr_un *)sa;
+		int addrlen = tosockaddr_addrlen(L, 1);
+		size_t path_len = sockaddr_un_path_len(sunaddr, addrlen);
+
 		lua_pushstring(L, "unix");
-		lua_pushstring(L, ((struct sockaddr_un *)sa)->sun_path);
+		lua_pushlstring(L, sunaddr->sun_path, path_len);
 		return 2;
+	}
 	}
 	return 0;
 }
@@ -383,9 +413,16 @@ static int meth_sockaddr_tostring(lua_State *L)
 		l = snprintf(buffer, sizeof(buffer), "sa.inet6: %pISpc", sa);
 		lua_pushlstring(L, buffer, l);
 		break;
-	case AF_UNIX:
-		lua_pushfstring(L, "sa.unix: %s", ((struct sockaddr_un *)sa)->sun_path);
+	case AF_UNIX: {
+		struct sockaddr_un *sunaddr = (struct sockaddr_un *)sa;
+		int addrlen = tosockaddr_addrlen(L, 1);
+		size_t sp_len = sockaddr_un_path_len(sunaddr, addrlen);
+
+		lua_pushliteral(L, "sa.unix: ");
+		lua_pushlstring(L, sunaddr->sun_path, sp_len);
+		lua_concat(L, 2);
 		break;
+	}
 	case AF_NETLINK:
 		lua_pushfstring(L, "sa.netlink: %d", ((struct sockaddr_nl *)sa)->nl_pid);
 		break;

--- a/security/lua/lua_object.h
+++ b/security/lua/lua_object.h
@@ -137,7 +137,6 @@
 	LUA_OBJECT(func,	net,		tundev,		void *,			NULL)	\
 	LUA_OBJECT(func,	net,		socket,		struct socket *,	NULL)	\
 	LUA_OBJECT(func,	net,		skb,		struct sk_buff *,	NULL)	\
-	LUA_OBJECT(func,	net,		sockaddr,	struct sockaddr *,	NULL)	\
 	LUA_OBJECT(func,	security,	key,		struct key *,		NULL)	\
 	LUA_OBJECT(object,	block,		bdev,		struct block_device *,	NULL)	\
 	LUA_OBJECT(object,	fs,		inode,		struct inode *,		NULL)	\
@@ -156,5 +155,84 @@
 	LUA_OBJECT_ ## blob ## _DEFINE(name, ctype, d)
 LUA_OBJECTS_LIST
 #undef LUA_OBJECT
+
+/*
+ * sockaddr is defined manually because it needs to carry addrlen alongside
+ * the pointer, so Lua-side methods can derive correct bounds for AF_UNIX
+ * sun_path (including abstract namespace sockets with embedded NULs).
+ *
+ * NOTE: These definitions mirror what LUA_OBJECT_func_DEFINE would generate.
+ * If that macro is ever extended (e.g. new raw/gc helpers), update this
+ * section to stay in sync.
+ */
+struct lua_sockaddr {
+	struct sockaddr *addr;
+	int addrlen;
+};
+
+static inline struct lua_sockaddr *newsockaddr_nomain(lua_State *L)
+{
+	struct lua_sockaddr *p = lua_newuserdata(L, sizeof(*p));
+
+	p->addr = NULL;
+	p->addrlen = 0;
+	luaL_getmetatable(L, METHOD_NAME(sockaddr));
+	lua_setmetatable(L, -2);
+	return p;
+}
+
+static inline struct lua_sockaddr *newsockaddr(lua_State *L)
+{
+	struct lua_sockaddr *p = newsockaddr_nomain(L);
+
+	lua_getfield(L, LUA_REGISTRYINDEX, CURR_ENV);
+	lua_setfenv(L, -2);
+	return p;
+}
+
+static inline struct lua_sockaddr *tosockaddarp(lua_State *L, int idx)
+{
+	return (struct lua_sockaddr *)checkudata3(L, idx, METHOD_NAME(sockaddr));
+}
+
+static inline struct sockaddr *tosockaddr(lua_State *L, int idx)
+{
+	return tosockaddarp(L, idx)->addr;
+}
+
+static inline int tosockaddr_addrlen(lua_State *L, int idx)
+{
+	return tosockaddarp(L, idx)->addrlen;
+}
+
+static int rawmeth_sockaddr_type(lua_State *L)
+{
+	lua_pushstring(L, "sockaddr");
+	lua_pushboolean(L, 0);
+	return 2;
+}
+
+static int rawmeth_sockaddr_tostring(lua_State *L)
+{
+	struct sockaddr *o = tosockaddr(L, 1);
+
+	lua_pushfstring(L, "sockaddr: <%p>", o);
+	return 1;
+}
+
+static inline void create_sockaddr_meta(lua_State *L,
+			const luaL_Reg *funcs, const luaL_Reg *gc)
+{
+	static const luaL_Reg basemeths[] = {
+		{ "__tostring",	rawmeth_sockaddr_tostring	},
+		{ NULL, NULL }
+	};
+	static const luaL_Reg rawmeths[] = {
+		{ "type",		rawmeth_sockaddr_type		},
+		{ NULL, NULL }
+	};
+	createmeta3(L, "sockaddr", basemeths, METHOD_NAME_GC(sockaddr), gc,
+		METHOD_NAME(sockaddr), funcs, METHOD_NAME_RAW(sockaddr), rawmeths);
+}
 
 #endif  /* ! _SECURITY_LUA_LSM_LUA_OBJECT_H */


### PR DESCRIPTION
Lua-LSM has several correctness fixes that belong together because they tighten hook data marshalling, xattr output ownership, and module teardown lifetime handling.

This series fixes:

- Lua string buffer length handling and AF_UNIX sockaddr length marshalling
- inode_init_security xattr validation and xattr name ownership
- overlong AF_UNIX sockaddr rejection
- shared dictionary lifetime and reference cleanup during unregister paths
- module teardown ordering across SRCU readers, lazy VM purge, and drained zombie modules

The changes keep unregister from freeing state still reachable from loaded Lua VMs, avoid running Lua teardown from task_call_func(), and ensure lazily drained modules are finalized once their VM-local references are gone.

Validation:

- git diff --check origin/lua-lsm..czy/lua-lsm

Signed-off-by: Zongyao Chen <ZongYao.Chen@linux.alibaba.com>