### PR TITLE
lua-lsm: fix string and AF_UNIX length marshalling

### DIFF
--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -1320,7 +1320,7 @@ LUA_LSM_INT_NAKED_DEFINE3(inode_listsecurity, struct inode *, inode,
 				const char *v = lua_tolstring(L, top, &len);
 				ret = (int)len;
 				if (buffer != NULL && len <= buffer_size)
-					memcpy(buffer, v, buffer_size);
+					memcpy(buffer, v, len);
 			}
 			break;
 		default:
@@ -1795,7 +1795,7 @@ LUA_LSM_INT_DEFINE2(kernel_load_data, enum kernel_load_data_id, id,
 LUA_LSM_INT_DEFINE4(kernel_post_load_data, char *, buf, loff_t, size,
 		enum kernel_load_data_id, id, char *, description)
 {
-	lua_pushstring(L, (const char *)buf);
+	lua_pushlstring(L, (const char *)buf, (size_t)size);
 	lua_pushinteger(L, (lua_Integer)size);
 	lua_pushnil(L);	/* TODO: id */
 	lua_pushstring(L, (const char *)description);
@@ -1821,7 +1821,7 @@ LUA_LSM_INT_DEFINE4(kernel_post_read_file, struct file *, file,
 		char *, buf, loff_t, size, enum kernel_read_file_id, id)
 {
 	*newfile(L) = file;
-	lua_pushstring(L, (const char *)buf);
+	lua_pushlstring(L, (const char *)buf, (size_t)size);
 	lua_pushinteger(L, (lua_Integer)size);
 	lua_pushnil(L);	/* TODO: id */
 }

--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -21,6 +21,7 @@
 #include <linux/syscalls.h>     /* for __MAP */
 #include <linux/timekeeping.h>  /* for ktime_get */
 #include <net/ipv6.h>
+#include <uapi/linux/un.h>
 #include <linux/lsm_hooks.h>
 #include <uapi/linux/lsm.h>
 #include <linux/lua.h>
@@ -2636,8 +2637,16 @@ static int build_sockaddr(lua_State *L, struct sockaddr *address, int addrlen)
 		if (addrlen < SIN6_LEN_RFC2133)
 			return 0;
 		break;
+	case AF_UNIX:
+		if (addrlen < offsetof(struct sockaddr_un, sun_path))
+			return 0;
+		break;
 	}
-	*newsockaddr(L) = address;
+	{
+		struct lua_sockaddr *p = newsockaddr(L);
+		p->addr = address;
+		p->addrlen = addrlen;
+	}
 	return 1;
 }
 

--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -2638,7 +2638,8 @@ static int build_sockaddr(lua_State *L, struct sockaddr *address, int addrlen)
 			return 0;
 		break;
 	case AF_UNIX:
-		if (addrlen < offsetof(struct sockaddr_un, sun_path))
+		if (addrlen < offsetof(struct sockaddr_un, sun_path) ||
+		    addrlen > sizeof(struct sockaddr_un))
 			return 0;
 		break;
 	}

--- a/security/lua/lua_net.c
+++ b/security/lua/lua_net.c
@@ -7,6 +7,7 @@
 
 #include "debug.h"
 #include <linux/printk.h>
+#include <linux/string.h>
 #include <linux/security.h>
 #include <linux/inet.h>
 #include <net/inet_sock.h>
@@ -68,6 +69,30 @@ static const char *family_tostring(sa_family_t sa_family)
 	}
 
 	return family;
+}
+
+static size_t sockaddr_un_path_len(const struct sockaddr_un *sunaddr, int addrlen)
+{
+	int offset = offsetof(struct sockaddr_un, sun_path);
+	size_t path_len;
+
+	if (addrlen <= offset)
+		return 0;
+
+	path_len = addrlen - offset;
+
+	/*
+	 * Pathname sockets are C strings; abstract sockets keep their full
+	 * declared length, including embedded NUL bytes.
+	 */
+	if (sunaddr->sun_path[0] != '\0') {
+		const char *nul = memchr(sunaddr->sun_path, '\0', path_len);
+
+		if (nul)
+			path_len = nul - sunaddr->sun_path;
+	}
+
+	return path_len;
 }
 
 /*********************************** sock ***********************************/
@@ -360,10 +385,15 @@ static int sockaddr_addrs(lua_State *L)
 		}
 		lua_pushinteger(L, ntohs(((struct sockaddr_in6 *)sa)->sin6_port));
 		return 3;
-	case AF_UNIX:
+	case AF_UNIX: {
+		struct sockaddr_un *sunaddr = (struct sockaddr_un *)sa;
+		int addrlen = tosockaddr_addrlen(L, 1);
+		size_t path_len = sockaddr_un_path_len(sunaddr, addrlen);
+
 		lua_pushstring(L, "unix");
-		lua_pushstring(L, ((struct sockaddr_un *)sa)->sun_path);
+		lua_pushlstring(L, sunaddr->sun_path, path_len);
 		return 2;
+	}
 	}
 	return 0;
 }
@@ -383,9 +413,16 @@ static int meth_sockaddr_tostring(lua_State *L)
 		l = snprintf(buffer, sizeof(buffer), "sa.inet6: %pISpc", sa);
 		lua_pushlstring(L, buffer, l);
 		break;
-	case AF_UNIX:
-		lua_pushfstring(L, "sa.unix: %s", ((struct sockaddr_un *)sa)->sun_path);
+	case AF_UNIX: {
+		struct sockaddr_un *sunaddr = (struct sockaddr_un *)sa;
+		int addrlen = tosockaddr_addrlen(L, 1);
+		size_t sp_len = sockaddr_un_path_len(sunaddr, addrlen);
+
+		lua_pushliteral(L, "sa.unix: ");
+		lua_pushlstring(L, sunaddr->sun_path, sp_len);
+		lua_concat(L, 2);
 		break;
+	}
 	case AF_NETLINK:
 		lua_pushfstring(L, "sa.netlink: %d", ((struct sockaddr_nl *)sa)->nl_pid);
 		break;

--- a/security/lua/lua_object.h
+++ b/security/lua/lua_object.h
@@ -137,7 +137,6 @@
 	LUA_OBJECT(func,	net,		tundev,		void *,			NULL)	\
 	LUA_OBJECT(func,	net,		socket,		struct socket *,	NULL)	\
 	LUA_OBJECT(func,	net,		skb,		struct sk_buff *,	NULL)	\
-	LUA_OBJECT(func,	net,		sockaddr,	struct sockaddr *,	NULL)	\
 	LUA_OBJECT(func,	security,	key,		struct key *,		NULL)	\
 	LUA_OBJECT(object,	block,		bdev,		struct block_device *,	NULL)	\
 	LUA_OBJECT(object,	fs,		inode,		struct inode *,		NULL)	\
@@ -156,5 +155,84 @@
 	LUA_OBJECT_ ## blob ## _DEFINE(name, ctype, d)
 LUA_OBJECTS_LIST
 #undef LUA_OBJECT
+
+/*
+ * sockaddr is defined manually because it needs to carry addrlen alongside
+ * the pointer, so Lua-side methods can derive correct bounds for AF_UNIX
+ * sun_path (including abstract namespace sockets with embedded NULs).
+ *
+ * NOTE: These definitions mirror what LUA_OBJECT_func_DEFINE would generate.
+ * If that macro is ever extended (e.g. new raw/gc helpers), update this
+ * section to stay in sync.
+ */
+struct lua_sockaddr {
+	struct sockaddr *addr;
+	int addrlen;
+};
+
+static inline struct lua_sockaddr *newsockaddr_nomain(lua_State *L)
+{
+	struct lua_sockaddr *p = lua_newuserdata(L, sizeof(*p));
+
+	p->addr = NULL;
+	p->addrlen = 0;
+	luaL_getmetatable(L, METHOD_NAME(sockaddr));
+	lua_setmetatable(L, -2);
+	return p;
+}
+
+static inline struct lua_sockaddr *newsockaddr(lua_State *L)
+{
+	struct lua_sockaddr *p = newsockaddr_nomain(L);
+
+	lua_getfield(L, LUA_REGISTRYINDEX, CURR_ENV);
+	lua_setfenv(L, -2);
+	return p;
+}
+
+static inline struct lua_sockaddr *tosockaddarp(lua_State *L, int idx)
+{
+	return (struct lua_sockaddr *)checkudata3(L, idx, METHOD_NAME(sockaddr));
+}
+
+static inline struct sockaddr *tosockaddr(lua_State *L, int idx)
+{
+	return tosockaddarp(L, idx)->addr;
+}
+
+static inline int tosockaddr_addrlen(lua_State *L, int idx)
+{
+	return tosockaddarp(L, idx)->addrlen;
+}
+
+static int rawmeth_sockaddr_type(lua_State *L)
+{
+	lua_pushstring(L, "sockaddr");
+	lua_pushboolean(L, 0);
+	return 2;
+}
+
+static int rawmeth_sockaddr_tostring(lua_State *L)
+{
+	struct sockaddr *o = tosockaddr(L, 1);
+
+	lua_pushfstring(L, "sockaddr: <%p>", o);
+	return 1;
+}
+
+static inline void create_sockaddr_meta(lua_State *L,
+			const luaL_Reg *funcs, const luaL_Reg *gc)
+{
+	static const luaL_Reg basemeths[] = {
+		{ "__tostring",	rawmeth_sockaddr_tostring	},
+		{ NULL, NULL }
+	};
+	static const luaL_Reg rawmeths[] = {
+		{ "type",		rawmeth_sockaddr_type		},
+		{ NULL, NULL }
+	};
+	createmeta3(L, "sockaddr", basemeths, METHOD_NAME_GC(sockaddr), gc,
+		METHOD_NAME(sockaddr), funcs, METHOD_NAME_RAW(sockaddr), rawmeths);
+}
 
 #endif  /* ! _SECURITY_LUA_LSM_LUA_OBJECT_H */


### PR DESCRIPTION
Lua-LSM passes Lua string buffers and AF_UNIX sockaddr data between Lua and LSM hook helpers. Tighten the length handling so hooks see the intended byte ranges and reject AF_UNIX socket addresses that cannot be represented safely.

This series fixes:

- Lua string buffer length handling
- AF_UNIX sockaddr marshalling lengths
- overlong AF_UNIX sockaddr rejection

Validation:

- git diff --check origin/lua-lsm..lua-lsm-marshalling-fixes

Replaces part of closed PR #4.

Signed-off-by: Zongyao Chen <ZongYao.Chen@linux.alibaba.com>