### PR TITLE
lua-lsm: fix inode_init_security xattr output handling

### DIFF
--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -795,7 +795,13 @@ static int lua_lsm_init_xattr(lua_State *L, int name_idx, int value_idx,
 	memcpy(buffer + value_len, name, name_len);
 	buffer[value_len + name_len] = '\0';
 
-	/* security_inode_init_security() frees value but not name. */
+	/*
+	 * FIXME: xattr->name must not share xattr->value storage. Some
+	 * initxattrs users, notably OCFS2, duplicate only value and keep
+	 * the name pointer after security_inode_init_security() frees value.
+	 * This needs separate name storage with a lifetime that covers those
+	 * delayed users.
+	 */
 	xattr->value = buffer;
 	xattr->value_len = value_len;
 	xattr->name = buffer + value_len;

--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -770,9 +770,16 @@ LUA_LSM_VOID_DEFINE1(inode_free_security_rcu, void *, inode_security)
 	lua_pushnil(L);	/* TODO: inode_security */
 }
 
-static int lua_lsm_check_xattr(const char *name, size_t name_len,
-			       size_t value_len)
+static int lua_lsm_init_xattr(lua_State *L, int name_idx, int value_idx,
+			      struct xattr *xattr)
 {
+	size_t name_len, value_len;
+	const char *name, *value;
+	char *buffer;
+
+	name = lua_tolstring(L, name_idx, &name_len);
+	value = lua_tolstring(L, value_idx, &value_len);
+
 	if (!name_len || name_len > XATTR_NAME_MAX - XATTR_SECURITY_PREFIX_LEN)
 		return -EINVAL;
 	if (memchr(name, '\0', name_len))
@@ -780,6 +787,18 @@ static int lua_lsm_check_xattr(const char *name, size_t name_len,
 	if (value_len > XATTR_SIZE_MAX)
 		return -E2BIG;
 
+	buffer = kmalloc(value_len + name_len + 1, GFP_NOFS);
+	if (!buffer)
+		return -ENOMEM;
+
+	memcpy(buffer, value, value_len);
+	memcpy(buffer + value_len, name, name_len);
+	buffer[value_len + name_len] = '\0';
+
+	/* security_inode_init_security() frees value but not name. */
+	xattr->value = buffer;
+	xattr->value_len = value_len;
+	xattr->name = buffer + value_len;
 	return 0;
 }
 
@@ -794,7 +813,7 @@ static int lua_lsm_check_xattr(const char *name, size_t name_len,
  *   false        : -EPERM
  *   false, errno : -errno
  *   nil, errno   : -errno
- *   name, value  : fill the xattr struct, XXX: name must not be freed
+ *   name, value  : fill the xattr struct
  */
 LUA_LSM_INT_NAKED_DEFINE5(inode_init_security, struct inode *, inode,
 		struct inode *, dir, const struct qstr *, qstr,
@@ -836,29 +855,10 @@ LUA_LSM_INT_NAKED_DEFINE5(inode_init_security, struct inode *, inode,
 				ret = -errno;
 		} else if (lua_isstring(L, top) && lua_isstring(L, top + 1)) {
 			struct xattr *xattr;
-			const char *name;
-			const char *value;
-			size_t name_len, len;
 
 			xattr = lsm_get_xattr_slot(xattrs, xattr_count);
-			if (xattr) {
-				name = lua_tolstring(L, top, &name_len);
-				value = lua_tolstring(L, top + 1, &len);
-				ret = lua_lsm_check_xattr(name, name_len, len);
-				if (ret)
-					break;
-
-				xattr->value = kmemdup(value, len, GFP_NOFS);
-				if (xattr->value == NULL) {
-					ret = -ENOMEM;
-					break;
-				}
-				xattr->value_len = len;
-				xattr->name = name;
-				ret = 0;
-			} else {
-				/* TODO */
-			}
+			if (xattr)
+				ret = lua_lsm_init_xattr(L, top, top + 1, xattr);
 		}
 		break;
 	}

--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -16,6 +16,7 @@
 #include <linux/compiler.h>
 #include <linux/rwlock.h>
 #include <linux/security.h>
+#include <linux/xattr.h>
 #include <linux/cred.h>
 #include <linux/prctl.h>
 #include <linux/syscalls.h>     /* for __MAP */
@@ -769,6 +770,19 @@ LUA_LSM_VOID_DEFINE1(inode_free_security_rcu, void *, inode_security)
 	lua_pushnil(L);	/* TODO: inode_security */
 }
 
+static int lua_lsm_check_xattr(const char *name, size_t name_len,
+			       size_t value_len)
+{
+	if (!name_len || name_len > XATTR_NAME_MAX - XATTR_SECURITY_PREFIX_LEN)
+		return -EINVAL;
+	if (memchr(name, '\0', name_len))
+		return -EINVAL;
+	if (value_len > XATTR_SIZE_MAX)
+		return -E2BIG;
+
+	return 0;
+}
+
 /**
  * inode_init_security
  * Default: -EOPNOTSUPP
@@ -822,19 +836,25 @@ LUA_LSM_INT_NAKED_DEFINE5(inode_init_security, struct inode *, inode,
 				ret = -errno;
 		} else if (lua_isstring(L, top) && lua_isstring(L, top + 1)) {
 			struct xattr *xattr;
+			const char *name;
 			const char *value;
-			size_t len;
+			size_t name_len, len;
 
 			xattr = lsm_get_xattr_slot(xattrs, xattr_count);
 			if (xattr) {
+				name = lua_tolstring(L, top, &name_len);
 				value = lua_tolstring(L, top + 1, &len);
+				ret = lua_lsm_check_xattr(name, name_len, len);
+				if (ret)
+					break;
+
 				xattr->value = kmemdup(value, len, GFP_NOFS);
 				if (xattr->value == NULL) {
 					ret = -ENOMEM;
 					break;
 				}
 				xattr->value_len = len;
-				xattr->name = lua_tostring(L, top);
+				xattr->name = name;
 				ret = 0;
 			} else {
 				/* TODO */


### PR DESCRIPTION
The inode_init_security hook returns xattr data back to the VFS, so Lua-LSM needs to validate the Lua-provided output and own any storage whose lifetime extends past the hook frame.

This series fixes:

- inode_init_security xattr output validation
- xattr name storage ownership
- documentation for the OCFS2 xattr name lifetime issue

Validation:

- git diff --check origin/lua-lsm..lua-lsm-inode-xattr-fixes

Replaces part of closed PR #4.

Signed-off-by: Zongyao Chen <ZongYao.Chen@linux.alibaba.com>