### PR TITLE
lua-lsm: fix Lua API object and capability validation

### DIFF
--- a/security/lua/auxlib.c
+++ b/security/lua/auxlib.c
@@ -540,6 +540,8 @@ int arg2cap(lua_State *L, int idx)
 	default:
 		return luaL_argerror(L, idx, "integer or string expected");
 	}
+	if (!cap_valid(cap))
+		return luaL_argerror(L, idx, "invalid capability");
 	return cap;
 }
 

--- a/security/lua/lua_fs.c
+++ b/security/lua/lua_fs.c
@@ -68,8 +68,9 @@ static int fs_dentry_dput(lua_State *L)
 static int fs_dentry_backing_inode(lua_State *L)
 {
 	struct dentry *dentry = todentry(L, 1);
+	struct inode *inode = d_backing_inode(dentry);
 
-	*newinode(L) = d_backing_inode(dentry);
+	inode ? *newinode(L) = inode : lua_pushnil(L);
 	return 1;
 }
 

--- a/security/lua/lua_kernel.c
+++ b/security/lua/lua_kernel.c
@@ -298,14 +298,16 @@ static int kernel_task_is_descendant(lua_State *L)
 {
 	struct task_struct *child = totask(L, 1);
 	struct task_struct *parent;
+	struct task_struct *parent_ref = NULL;
 	int tt = lua_type(L, 2);
 	int res = 0;
 
 	switch (tt) {
 	case LUA_TNUMBER:
-		parent = find_get_task_by_vpid((pid_t)lua_tointeger(L, 2));
-		if (!parent)
+		parent_ref = find_get_task_by_vpid((pid_t)lua_tointeger(L, 2));
+		if (!parent_ref)
 			return luaL_argerror(L, 2, "invalid pid");
+		parent = parent_ref;
 		break;
 	case LUA_TUSERDATA:
 		parent = totask(L, 2);
@@ -328,8 +330,8 @@ static int kernel_task_is_descendant(lua_State *L)
 	}
 	rcu_read_unlock();
 
-	if (tt == LUA_TNUMBER)
-		put_task_struct(parent);
+	if (parent_ref)
+		put_task_struct(parent_ref);
 
 	lua_pushboolean(L, res);
 	return 1;

--- a/security/lua/lua_net.c
+++ b/security/lua/lua_net.c
@@ -75,7 +75,9 @@ static const char *family_tostring(sa_family_t sa_family)
 static int net_sock_socket(lua_State *L)
 {
 	struct sock *sk = tosock(L, 1);
-	*newsocket(L) = sk->sk_socket;
+	struct socket *sock = sk->sk_socket;
+
+	sock ? *newsocket(L) = sock : lua_pushnil(L);
 	return 1;
 }
 
@@ -232,7 +234,9 @@ static int net_socket_release(lua_State *L)
 static int net_socket_sock(lua_State *L)
 {
 	struct socket *sock = tosocket(L, 1);
-	*newsock(L) = sock->sk;
+	struct sock *sk = sock->sk;
+
+	sk ? *newsock(L) = sk : lua_pushnil(L);
 	return 1;
 }
 
@@ -255,14 +259,18 @@ static const luaL_Reg socket_meth[] = {
 static int net_skb_sock(lua_State *L)
 {
 	struct sk_buff *skb = toskb(L, 1);
-	*newsock(L) = skb->sk;
+	struct sock *sk = skb->sk;
+
+	sk ? *newsock(L) = sk : lua_pushnil(L);
 	return 1;
 }
 
 static int net_skb_full_sk(lua_State *L)
 {
 	struct sk_buff *skb = toskb(L, 1);
-	*newsock(L) = skb_to_full_sk(skb);
+	struct sock *sk = skb_to_full_sk(skb);
+
+	sk ? *newsock(L) = sk : lua_pushnil(L);
 	return 1;
 }
 


### PR DESCRIPTION
Lua-LSM exposes helper objects and capability operations directly to Lua policy code. Tighten the API boundary so policy input cannot produce invalid kernel object references or unchecked capability bit operations.

This series fixes:

- task:is_descendant(pid) putting the group leader instead of the looked-up task when pid names a non-leader thread
- nullable helper results being wrapped as typed userdata instead of nil
- numeric capability arguments reaching capability helpers without cap_valid() validation

Validation:

- ./scripts/checkpatch.pl --git origin/lua-lsm..HEAD
- git diff --check origin/lua-lsm..HEAD

Signed-off-by: Zongyao Chen <ZongYao.Chen@linux.alibaba.com>