### PR TITLE
lua-lsm: wait for SRCU readers before freeing module

### DIFF
--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -1267,6 +1267,7 @@ int lua_lsm_module_unregister(const char *name)
 
 	if (atomic_sub_return(count, &module->nloaded) == 0) {
 		list_del_rcu(&module->list);
+		synchronize_srcu(&modules_ss);
 		lua_lsm_module_free(module);
 		err = 0;
 	} else {

--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -16,6 +16,7 @@
 #include <linux/compiler.h>
 #include <linux/rwlock.h>
 #include <linux/security.h>
+#include <linux/xattr.h>
 #include <linux/cred.h>
 #include <linux/prctl.h>
 #include <linux/syscalls.h>     /* for __MAP */
@@ -769,6 +770,44 @@ LUA_LSM_VOID_DEFINE1(inode_free_security_rcu, void *, inode_security)
 	lua_pushnil(L);	/* TODO: inode_security */
 }
 
+static int lua_lsm_init_xattr(lua_State *L, int name_idx, int value_idx,
+			      struct xattr *xattr)
+{
+	size_t name_len, value_len;
+	const char *name, *value;
+	char *buffer;
+
+	name = lua_tolstring(L, name_idx, &name_len);
+	value = lua_tolstring(L, value_idx, &value_len);
+
+	if (!name_len || name_len > XATTR_NAME_MAX - XATTR_SECURITY_PREFIX_LEN)
+		return -EINVAL;
+	if (memchr(name, '\0', name_len))
+		return -EINVAL;
+	if (value_len > XATTR_SIZE_MAX)
+		return -E2BIG;
+
+	buffer = kmalloc(value_len + name_len + 1, GFP_NOFS);
+	if (!buffer)
+		return -ENOMEM;
+
+	memcpy(buffer, value, value_len);
+	memcpy(buffer + value_len, name, name_len);
+	buffer[value_len + name_len] = '\0';
+
+	/*
+	 * FIXME: xattr->name must not share xattr->value storage. Some
+	 * initxattrs users, notably OCFS2, duplicate only value and keep
+	 * the name pointer after security_inode_init_security() frees value.
+	 * This needs separate name storage with a lifetime that covers those
+	 * delayed users.
+	 */
+	xattr->value = buffer;
+	xattr->value_len = value_len;
+	xattr->name = buffer + value_len;
+	return 0;
+}
+
 /**
  * inode_init_security
  * Default: -EOPNOTSUPP
@@ -780,7 +819,7 @@ LUA_LSM_VOID_DEFINE1(inode_free_security_rcu, void *, inode_security)
  *   false        : -EPERM
  *   false, errno : -errno
  *   nil, errno   : -errno
- *   name, value  : fill the xattr struct, XXX: name must not be freed
+ *   name, value  : fill the xattr struct
  */
 LUA_LSM_INT_NAKED_DEFINE5(inode_init_security, struct inode *, inode,
 		struct inode *, dir, const struct qstr *, qstr,
@@ -822,23 +861,10 @@ LUA_LSM_INT_NAKED_DEFINE5(inode_init_security, struct inode *, inode,
 				ret = -errno;
 		} else if (lua_isstring(L, top) && lua_isstring(L, top + 1)) {
 			struct xattr *xattr;
-			const char *value;
-			size_t len;
 
 			xattr = lsm_get_xattr_slot(xattrs, xattr_count);
-			if (xattr) {
-				value = lua_tolstring(L, top + 1, &len);
-				xattr->value = kmemdup(value, len, GFP_NOFS);
-				if (xattr->value == NULL) {
-					ret = -ENOMEM;
-					break;
-				}
-				xattr->value_len = len;
-				xattr->name = lua_tostring(L, top);
-				ret = 0;
-			} else {
-				/* TODO */
-			}
+			if (xattr)
+				ret = lua_lsm_init_xattr(L, top, top + 1, xattr);
 		}
 		break;
 	}


### PR DESCRIPTION
Lua-LSM publishes module pointers under modules_ss SRCU. The unregister path removes a module from the list before freeing it, but readers that already entered the SRCU read-side critical section may still hold the old pointer.

Wait for an SRCU grace period after unlinking the module and before freeing its storage.

Validation:

- ./scripts/checkpatch.pl --git origin/lua-lsm..lua-lsm-b53870b-srcu-module-free
- git diff --check origin/lua-lsm..lua-lsm-b53870b-srcu-module-free

Signed-off-by: Zongyao Chen <ZongYao.Chen@linux.alibaba.com>