### PR TITLE
lua-lsm: don't store filp_open errors in file userdata

### DIFF
--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -16,6 +16,7 @@
 #include <linux/compiler.h>
 #include <linux/rwlock.h>
 #include <linux/security.h>
+#include <linux/xattr.h>
 #include <linux/cred.h>
 #include <linux/prctl.h>
 #include <linux/syscalls.h>     /* for __MAP */
@@ -769,6 +770,44 @@ LUA_LSM_VOID_DEFINE1(inode_free_security_rcu, void *, inode_security)
 	lua_pushnil(L);	/* TODO: inode_security */
 }
 
+static int lua_lsm_init_xattr(lua_State *L, int name_idx, int value_idx,
+			      struct xattr *xattr)
+{
+	size_t name_len, value_len;
+	const char *name, *value;
+	char *buffer;
+
+	name = lua_tolstring(L, name_idx, &name_len);
+	value = lua_tolstring(L, value_idx, &value_len);
+
+	if (!name_len || name_len > XATTR_NAME_MAX - XATTR_SECURITY_PREFIX_LEN)
+		return -EINVAL;
+	if (memchr(name, '\0', name_len))
+		return -EINVAL;
+	if (value_len > XATTR_SIZE_MAX)
+		return -E2BIG;
+
+	buffer = kmalloc(value_len + name_len + 1, GFP_NOFS);
+	if (!buffer)
+		return -ENOMEM;
+
+	memcpy(buffer, value, value_len);
+	memcpy(buffer + value_len, name, name_len);
+	buffer[value_len + name_len] = '\0';
+
+	/*
+	 * FIXME: xattr->name must not share xattr->value storage. Some
+	 * initxattrs users, notably OCFS2, duplicate only value and keep
+	 * the name pointer after security_inode_init_security() frees value.
+	 * This needs separate name storage with a lifetime that covers those
+	 * delayed users.
+	 */
+	xattr->value = buffer;
+	xattr->value_len = value_len;
+	xattr->name = buffer + value_len;
+	return 0;
+}
+
 /**
  * inode_init_security
  * Default: -EOPNOTSUPP
@@ -780,7 +819,7 @@ LUA_LSM_VOID_DEFINE1(inode_free_security_rcu, void *, inode_security)
  *   false        : -EPERM
  *   false, errno : -errno
  *   nil, errno   : -errno
- *   name, value  : fill the xattr struct, XXX: name must not be freed
+ *   name, value  : fill the xattr struct
  */
 LUA_LSM_INT_NAKED_DEFINE5(inode_init_security, struct inode *, inode,
 		struct inode *, dir, const struct qstr *, qstr,
@@ -822,23 +861,10 @@ LUA_LSM_INT_NAKED_DEFINE5(inode_init_security, struct inode *, inode,
 				ret = -errno;
 		} else if (lua_isstring(L, top) && lua_isstring(L, top + 1)) {
 			struct xattr *xattr;
-			const char *value;
-			size_t len;
 
 			xattr = lsm_get_xattr_slot(xattrs, xattr_count);
-			if (xattr) {
-				value = lua_tolstring(L, top + 1, &len);
-				xattr->value = kmemdup(value, len, GFP_NOFS);
-				if (xattr->value == NULL) {
-					ret = -ENOMEM;
-					break;
-				}
-				xattr->value_len = len;
-				xattr->name = lua_tostring(L, top);
-				ret = 0;
-			} else {
-				/* TODO */
-			}
+			if (xattr)
+				ret = lua_lsm_init_xattr(L, top, top + 1, xattr);
 		}
 		break;
 	}

--- a/security/lua/lua_fs.c
+++ b/security/lua/lua_fs.c
@@ -554,13 +554,15 @@ static int fs_filp_open(lua_State *L)
 	const char *filename = luaL_checkstring(L, 1);
 	int flags = luaL_checkinteger(L, 2);
 	umode_t mode = luaL_checkinteger(L, 3);
+	struct file *file;
 	struct file **filp = newgcfile(L);
-	*filp = filp_open(filename, flags, mode);
-	if (IS_ERR(*filp)) {
+	file = filp_open(filename, flags, mode);
+	if (IS_ERR(file)) {
 		lua_pushnil(L);
-		lua_pushinteger(L, PTR_ERR(*filp));
+		lua_pushinteger(L, PTR_ERR(file));
 		return 2;
 	}
+	*filp = file;
 	return 1;
 }
 


### PR DESCRIPTION
filp_open() can return ERR_PTR(). Keep that value out of the GC-backed userdata so meth_file_gc() never passes an error pointer to fput().

Store the file pointer in a temporary first and publish it to the userdata only after the open succeeds.

Validation:

- ./scripts/checkpatch.pl --git origin/lua-lsm..lua-lsm-da2dbb5-file-userdata-errptr
- git diff --check origin/lua-lsm..lua-lsm-da2dbb5-file-userdata-errptr

Signed-off-by: Zongyao Chen <ZongYao.Chen@linux.alibaba.com>