### PR TITLE
lua-lsm: return nil for missing wrapped objects

### DIFF
--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -16,6 +16,7 @@
 #include <linux/compiler.h>
 #include <linux/rwlock.h>
 #include <linux/security.h>
+#include <linux/xattr.h>
 #include <linux/cred.h>
 #include <linux/prctl.h>
 #include <linux/syscalls.h>     /* for __MAP */
@@ -769,6 +770,44 @@ LUA_LSM_VOID_DEFINE1(inode_free_security_rcu, void *, inode_security)
 	lua_pushnil(L);	/* TODO: inode_security */
 }
 
+static int lua_lsm_init_xattr(lua_State *L, int name_idx, int value_idx,
+			      struct xattr *xattr)
+{
+	size_t name_len, value_len;
+	const char *name, *value;
+	char *buffer;
+
+	name = lua_tolstring(L, name_idx, &name_len);
+	value = lua_tolstring(L, value_idx, &value_len);
+
+	if (!name_len || name_len > XATTR_NAME_MAX - XATTR_SECURITY_PREFIX_LEN)
+		return -EINVAL;
+	if (memchr(name, '\0', name_len))
+		return -EINVAL;
+	if (value_len > XATTR_SIZE_MAX)
+		return -E2BIG;
+
+	buffer = kmalloc(value_len + name_len + 1, GFP_NOFS);
+	if (!buffer)
+		return -ENOMEM;
+
+	memcpy(buffer, value, value_len);
+	memcpy(buffer + value_len, name, name_len);
+	buffer[value_len + name_len] = '\0';
+
+	/*
+	 * FIXME: xattr->name must not share xattr->value storage. Some
+	 * initxattrs users, notably OCFS2, duplicate only value and keep
+	 * the name pointer after security_inode_init_security() frees value.
+	 * This needs separate name storage with a lifetime that covers those
+	 * delayed users.
+	 */
+	xattr->value = buffer;
+	xattr->value_len = value_len;
+	xattr->name = buffer + value_len;
+	return 0;
+}
+
 /**
  * inode_init_security
  * Default: -EOPNOTSUPP
@@ -780,7 +819,7 @@ LUA_LSM_VOID_DEFINE1(inode_free_security_rcu, void *, inode_security)
  *   false        : -EPERM
  *   false, errno : -errno
  *   nil, errno   : -errno
- *   name, value  : fill the xattr struct, XXX: name must not be freed
+ *   name, value  : fill the xattr struct
  */
 LUA_LSM_INT_NAKED_DEFINE5(inode_init_security, struct inode *, inode,
 		struct inode *, dir, const struct qstr *, qstr,
@@ -822,23 +861,10 @@ LUA_LSM_INT_NAKED_DEFINE5(inode_init_security, struct inode *, inode,
 				ret = -errno;
 		} else if (lua_isstring(L, top) && lua_isstring(L, top + 1)) {
 			struct xattr *xattr;
-			const char *value;
-			size_t len;
 
 			xattr = lsm_get_xattr_slot(xattrs, xattr_count);
-			if (xattr) {
-				value = lua_tolstring(L, top + 1, &len);
-				xattr->value = kmemdup(value, len, GFP_NOFS);
-				if (xattr->value == NULL) {
-					ret = -ENOMEM;
-					break;
-				}
-				xattr->value_len = len;
-				xattr->name = lua_tostring(L, top);
-				ret = 0;
-			} else {
-				/* TODO */
-			}
+			if (xattr)
+				ret = lua_lsm_init_xattr(L, top, top + 1, xattr);
 		}
 		break;
 	}

--- a/security/lua/lua_fs.c
+++ b/security/lua/lua_fs.c
@@ -68,8 +68,9 @@ static int fs_dentry_dput(lua_State *L)
 static int fs_dentry_backing_inode(lua_State *L)
 {
 	struct dentry *dentry = todentry(L, 1);
+	struct inode *inode = d_backing_inode(dentry);
 
-	*newinode(L) = d_backing_inode(dentry);
+	inode ? *newinode(L) = inode : lua_pushnil(L);
 	return 1;
 }
 

--- a/security/lua/lua_net.c
+++ b/security/lua/lua_net.c
@@ -75,7 +75,9 @@ static const char *family_tostring(sa_family_t sa_family)
 static int net_sock_socket(lua_State *L)
 {
 	struct sock *sk = tosock(L, 1);
-	*newsocket(L) = sk->sk_socket;
+	struct socket *sock = sk->sk_socket;
+
+	sock ? *newsocket(L) = sock : lua_pushnil(L);
 	return 1;
 }
 
@@ -232,7 +234,9 @@ static int net_socket_release(lua_State *L)
 static int net_socket_sock(lua_State *L)
 {
 	struct socket *sock = tosocket(L, 1);
-	*newsock(L) = sock->sk;
+	struct sock *sk = sock->sk;
+
+	sk ? *newsock(L) = sk : lua_pushnil(L);
 	return 1;
 }
 
@@ -255,14 +259,18 @@ static const luaL_Reg socket_meth[] = {
 static int net_skb_sock(lua_State *L)
 {
 	struct sk_buff *skb = toskb(L, 1);
-	*newsock(L) = skb->sk;
+	struct sock *sk = skb->sk;
+
+	sk ? *newsock(L) = sk : lua_pushnil(L);
 	return 1;
 }
 
 static int net_skb_full_sk(lua_State *L)
 {
 	struct sk_buff *skb = toskb(L, 1);
-	*newsock(L) = skb_to_full_sk(skb);
+	struct sock *sk = skb_to_full_sk(skb);
+
+	sk ? *newsock(L) = sk : lua_pushnil(L);
 	return 1;
 }
 


### PR DESCRIPTION
Some Lua accessors expose optional kernel pointers. d_backing_inode(), sk->sk_socket, sock->sk, skb->sk, and skb_to_full_sk() can return NULL, but the accessors wrapped those values as typed userdata.

Lua policy then sees a non-nil object and can call methods that dereference the stored pointer without another NULL check.

Return nil for missing optional objects, matching the existing convention used by Lua-LSM hook argument marshalling.

Validation:

- ./scripts/checkpatch.pl --git origin/lua-lsm..lua-lsm-96cfcf8-null-wrapped-objects
- git diff --check origin/lua-lsm..lua-lsm-96cfcf8-null-wrapped-objects

Signed-off-by: Zongyao Chen <ZongYao.Chen@linux.alibaba.com>