### PR TITLE
lua-lsm: expose kernel file load ids

### DIFF
--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -1823,7 +1823,6 @@ LUA_LSM_INT_DEFINE4(kernel_post_load_data, char *, buf, loff_t, size,
 		enum kernel_load_data_id, id, char *, description)
 {
 	lua_pushlstring(L, (const char *)buf, (size_t)size);
-	lua_pushinteger(L, (lua_Integer)size);
 	lua_pushstring(L, kernel_load_data_id_str(id));
 	lua_pushstring(L, (const char *)description);
 }
@@ -1849,7 +1848,6 @@ LUA_LSM_INT_DEFINE4(kernel_post_read_file, struct file *, file,
 {
 	*newfile(L) = file;
 	lua_pushlstring(L, (const char *)buf, (size_t)size);
-	lua_pushinteger(L, (lua_Integer)size);
 	lua_pushstring(L, kernel_read_file_id_str(id));
 }
 

--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -21,6 +21,7 @@
 #include <linux/prctl.h>
 #include <linux/syscalls.h>     /* for __MAP */
 #include <linux/timekeeping.h>  /* for ktime_get */
+#include <linux/kernel_read_file.h>
 #include <net/ipv6.h>
 #include <linux/lsm_hooks.h>
 #include <uapi/linux/lsm.h>
@@ -1804,18 +1805,18 @@ LUA_LSM_INT_DEFINE1(kernel_module_request, char *, kmod_name)
 }
 
 /**
- * TODO: kernel_load_data
+ * kernel_load_data
  * Default: 0
  */
 LUA_LSM_INT_DEFINE2(kernel_load_data, enum kernel_load_data_id, id,
 		bool, contents)
 {
-	lua_pushnil(L);	/* TODO: id */
+	lua_pushstring(L, kernel_load_data_id_str(id));
 	lua_pushboolean(L, (int)contents);
 }
 
 /**
- * TODO: kernel_post_load_data
+ * kernel_post_load_data
  * Default: 0
  */
 LUA_LSM_INT_DEFINE4(kernel_post_load_data, char *, buf, loff_t, size,
@@ -1823,24 +1824,24 @@ LUA_LSM_INT_DEFINE4(kernel_post_load_data, char *, buf, loff_t, size,
 {
 	lua_pushlstring(L, (const char *)buf, (size_t)size);
 	lua_pushinteger(L, (lua_Integer)size);
-	lua_pushnil(L);	/* TODO: id */
+	lua_pushstring(L, kernel_load_data_id_str(id));
 	lua_pushstring(L, (const char *)description);
 }
 
 /**
- * TODO: kernel_read_file
+ * kernel_read_file
  * Default: 0
  */
 LUA_LSM_INT_DEFINE3(kernel_read_file, struct file *, file,
 		enum kernel_read_file_id, id, bool, contents)
 {
 	*newfile(L) = file;
-	lua_pushnil(L);	/* TODO: id */
+	lua_pushstring(L, kernel_read_file_id_str(id));
 	lua_pushboolean(L, (int)contents);
 }
 
 /**
- * TODO: kernel_post_read_file
+ * kernel_post_read_file
  * Default: 0
  */
 LUA_LSM_INT_DEFINE4(kernel_post_read_file, struct file *, file,
@@ -1849,7 +1850,7 @@ LUA_LSM_INT_DEFINE4(kernel_post_read_file, struct file *, file,
 	*newfile(L) = file;
 	lua_pushlstring(L, (const char *)buf, (size_t)size);
 	lua_pushinteger(L, (lua_Integer)size);
-	lua_pushnil(L);	/* TODO: id */
+	lua_pushstring(L, kernel_read_file_id_str(id));
 }
 
 static void build_lsm_setid_flags(lua_State *L, int flags)


### PR DESCRIPTION
Lua-LSM currently leaves the file/load id arguments for kernel_load_data(), kernel_post_load_data(), kernel_read_file(), and kernel_post_read_file() as nil placeholders. This makes Lua policy unable to distinguish kernel modules, firmware, security policy loads, and other kernel file/load users without looking at unrelated context.

Expose those ids as the stable strings returned by kernel_load_data_id_str() and kernel_read_file_id_str(), and drop the separate Lua-visible size argument from the post hooks. The post hooks already expose the data as binary-safe Lua strings, so policy can use the Lua length operator instead.

Example Lua policy:

```lua
return {
    name = "file-load-policy",
    author = "Zongyao Chen",
    license = "GPL",

    kernel_load_data = function(id, contents)
        if id == "kernel-module" and not contents then
            return false, errno.EPERM
        end
        return true
    end,

    kernel_post_load_data = function(data, id, description)
        if id ~= "kernel-module" then
            return true
        end

        if #data < 4 or data:sub(1, 4) ~= "\127ELF" then
            return false, errno.EPERM
        end

        return true
    end,

    kernel_read_file = function(file, id, contents)
        return true
    end,

    kernel_post_read_file = function(file, data, id)
        if id == "kernel-module" and #data >= 4 then
            return data:sub(1, 4) == "\127ELF"
        end
        return true
    end,
}
```

The series contains these commits:

- lua-lsm: expose kernel file load ids to Lua hooks
- lua-lsm: drop redundant size args for file data hooks

Validation:

- ./scripts/checkpatch.pl --git origin/lua-lsm..lua-lsm-file-load-ids
- git diff --check origin/lua-lsm..lua-lsm-file-load-ids

Signed-off-by: Zongyao Chen <ZongYao.Chen@linux.alibaba.com>
