### PR TITLE
lua-lsm: reset dirty VMs on task exit

### DIFF
--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -423,6 +423,14 @@ static void lvm_vm_reset(struct lvm_state *lvm)
 	lua_gc(L, LUA_GCCOLLECT, 0);
 }
 
+static void lvm_mark_dirty(lua_State *L)
+{
+	void *ud;
+
+	lua_getallocf(L, &ud);
+	((struct lvm_state *)ud)->dirty = true;
+}
+
 static lua_State *
 lvm_get_from_task(const struct task_struct *task, bool exclusive)
 {
@@ -640,6 +648,7 @@ static int lua_modules_index(lua_State *L)
 		if (strcmp(module->name, key) != 0)
 			continue;
 
+		lvm_mark_dirty(L);
 		err = module_load(L, module);
 		if (err) {
 			__log_err("load: %s, err = %d, top = %d\n",
@@ -1344,8 +1353,11 @@ void task_blob_free(struct task_struct *task)
 	struct lvm_state *lvm = llt->lvm;
 
 	if (lvm) {
-		lua_modules_free(task, lvm->L);
-		lvm_vm_reset(lvm);
+		if (lvm->dirty) {
+			lua_modules_free(task, lvm->L);
+			lvm_vm_reset(lvm);
+			lvm->dirty = false;
+		}
 		refcount_init(&lvm->refcount, 0);
 		lvm_pool_put(lvm);
 		llt->lvm = NULL;

--- a/security/lua/lsm.h
+++ b/security/lua/lsm.h
@@ -125,6 +125,7 @@ struct lvm_state {
 	lua_State *L;
 	atomic_t refcount;
 	struct lvm_state *next;
+	bool dirty;
 #ifdef CONFIG_SECURITY_LUA_LSM_STATS
 	atomic64_t nalloc;
 	atomic64_t nrealloc;


### PR DESCRIPTION
Lua-LSM reuses per-task Lua VMs through the LVM pool. A VM that lazily loads a policy module can keep module tables and registry state after the task exits, so reusing that VM for a later task can leave stale Lua module state reachable.

Track when a VM has been dirtied by lazy module loading and reset it from task_blob_free() before returning it to the pool. Clean VMs still take the existing fast path, while dirty VMs drop loaded modules and restore the registry state at task exit.

Validation:

- ./scripts/checkpatch.pl --git origin/lua-lsm..lua-lsm-dirty-vm-reset
- git diff --check origin/lua-lsm..lua-lsm-dirty-vm-reset

Signed-off-by: Zongyao Chen <ZongYao.Chen@linux.alibaba.com>
