### PR TITLE
lua-lsm: skip empty kvcache dict free

### DIFF
--- a/security/lua/kvcache.c
+++ b/security/lua/kvcache.c
@@ -450,6 +450,9 @@ void kvcache_dict_free(struct kvcache_dict *dict)
 	struct kvcache_node *node, *n;
 	struct lua_lsm_module *module;
 
+	if (atomic_read(&dict->count) == 0)
+		return;
+
 	spin_lock_bh(&nodes_gc_lock);
 	RB_FOREACH(node, kvcache, &dict->root) {
 		module = node->module;


### PR DESCRIPTION
kvcache_dict_free() can run for Lua-LSM objects that never stored object-local or shared key/value state. In that case the dictionary rbtree is empty, so taking the global nodes GC lock and walking the tree does unnecessary teardown work.

Return immediately when the dictionary count is zero. Non-empty dictionaries keep the existing unlink and drop path unchanged.

Validation:

- ./scripts/checkpatch.pl --git origin/lua-lsm..lua-lsm-kvcache-empty-free
- git diff --check origin/lua-lsm..lua-lsm-kvcache-empty-free

Signed-off-by: Zongyao Chen <ZongYao.Chen@linux.alibaba.com>
