### PR TITLE
lua-lsm: build task Lua VMs lazily

### DIFF
--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -267,6 +267,8 @@ static inline void lvm_stats_memalloc(struct lvm_state *lvm, void *ptr,
 
 static DEFINE_PER_CPU(struct lvm_state *, irq_lvms);
 
+static lua_State *lvm_build_lua_state(struct lvm_state *lvm);
+static void *lvm_alloc(void *ud, void *ptr, size_t osize, size_t nsize);
 static int lua_state_alloc(struct lvm_state *lvm);
 static void lua_state_free(struct lvm_state *lvm);
 
@@ -438,8 +440,51 @@ lvm_get_from_task(const struct task_struct *task, bool exclusive)
 {
 	struct lua_lsm_task *llt = lua_lsm_task(task);
 	struct lvm_state *lvm = llt->lvm;
-	int n = refcount_acquire(&lvm->refcount);
+	lua_State *L;
+	int n;
 
+	/* Pairs with cmpxchg_release() that publishes a built lua_State. */
+	L = smp_load_acquire(&lvm->L);
+	if (unlikely(!L)) {
+		struct lvm_state *pooled = lvm_pool_get();
+		struct lvm_state build_owner;
+		struct lvm_state *owner;
+		lua_State *built;
+
+		if (pooled) {
+			built = pooled->L;
+			pooled->L = NULL;
+			owner = pooled;
+		} else {
+			memset(&build_owner, 0, sizeof(build_owner));
+			built = lvm_build_lua_state(&build_owner);
+			if (!built)
+				return NULL;
+			owner = &build_owner;
+		}
+		if (cmpxchg_release(&lvm->L, NULL, built) != NULL) {
+			lua_close(built);
+			lvm_stats_vmfree();
+			kfree(pooled);
+		} else {
+			lua_setallocf(built, lvm_alloc, lvm);
+#ifdef CONFIG_SECURITY_LUA_LSM_STATS
+			atomic64_set(&lvm->nalloc,
+				atomic64_read(&owner->nalloc));
+			atomic64_set(&lvm->nrealloc,
+				atomic64_read(&owner->nrealloc));
+			atomic64_set(&lvm->nfree,
+				atomic64_read(&owner->nfree));
+#endif
+			kfree(pooled);
+		}
+		/* Pairs with cmpxchg_release() above. */
+		L = smp_load_acquire(&lvm->L);
+		if (WARN_ON_ONCE(!L))
+			return NULL;
+	}
+
+	n = refcount_acquire(&lvm->refcount);
 	if (exclusive && n != 1) {
 		refcount_release(&lvm->refcount);
 		return NULL;
@@ -447,7 +492,7 @@ lvm_get_from_task(const struct task_struct *task, bool exclusive)
 	WARN_ON(n != 1);
 	KASSERT(n == 1, ("<%s> Lua VM is reused, refcount = %d\n",
 			 task->comm, n));
-	return lvm->L;
+	return L;
 }
 
 static void lvm_put_to_task(const struct task_struct *task, lua_State *L)
@@ -785,16 +830,20 @@ static int lvm_pmain(lua_State *L)
 	return 1;
 }
 
-static int lua_state_alloc(struct lvm_state *lvm)
+/*
+ * Build a fully-initialized lua_State without publishing it into any
+ * lvm_state. The returned state has openlibs, lualibs, shdict, and the
+ * _MODULES table installed; the caller is responsible for installing it.
+ */
+static lua_State *lvm_build_lua_state(struct lvm_state *lvm)
 {
 	lua_State *L;
 	int status;
 
 	L = lua_newstate(lvm_alloc, lvm);
 	if (!L)
-		return -ENOMEM;
+		return NULL;
 
-	lvm->L = L;
 	lua_atpanic(L, lvm_panic);
 	lua_gc(L, LUA_GCSTOP, 0);
 
@@ -803,23 +852,28 @@ static int lua_state_alloc(struct lvm_state *lvm)
 	if (status != 0) {
 		__log_err("pcall: status = %d, top = %d, %s\n",
 			  status, lua_gettop(L), lua_tostring(L, -1));
-		status = -ENOEXEC;
-	} else if (!lua_toboolean(L, -1) && lua_gettop(L) != 1) {
+		lua_close(L);
+		return NULL;
+	}
+	if (!lua_toboolean(L, -1) && lua_gettop(L) != 1) {
 		__log_err("lvm_pmain: top = %d, stack[top] = [%s]\n",
 			  lua_gettop(L), luaL_typename(L, -1));
-		status = -EFAULT;
-	} else {
-		lua_pop(L, 1);		/* pop boolean result */
-		status = 0;
-	}
-
-	if (status != 0) {
 		lua_close(L);
-		lvm->L = NULL;
-		return status;
+		return NULL;
 	}
+	lua_pop(L, 1);
 
 	lvm_stats_vmalloc();
+	return L;
+}
+
+static int lua_state_alloc(struct lvm_state *lvm)
+{
+	lua_State *L = lvm_build_lua_state(lvm);
+
+	if (!L)
+		return -ENOMEM;
+	lvm->L = L;
 	return 0;
 }
 
@@ -1324,30 +1378,14 @@ int task_blob_init(struct task_struct *task)
 {
 	struct lua_lsm_task *llt = lua_lsm_task(task);
 	struct lvm_state *lvm;
-	int err;
 
 	kvcache_dict_init(&llt->dict);
 
-	lvm = lvm_pool_get();
-	if (!lvm) {
-		lvm = kzalloc(sizeof(*lvm), GFP_KERNEL);
-		if (!lvm)
-			return -ENOMEM;
-		err = lua_state_alloc(lvm);
-		if (err) {
-			kfree(lvm);
-			return err;
-		}
-	}
+	lvm = kzalloc(sizeof(*lvm), GFP_KERNEL);
+	if (!lvm)
+		return -ENOMEM;
 
-	refcount_init(&lvm->refcount, 0);
-#ifdef CONFIG_SECURITY_LUA_LSM_STATS
-	atomic64_set(&lvm->nalloc, 0);
-	atomic64_set(&lvm->nrealloc, 0);
-	atomic64_set(&lvm->nfree, 0);
-#endif
 	llt->lvm = lvm;
-
 	return 0;
 }
 
@@ -1357,13 +1395,17 @@ void task_blob_free(struct task_struct *task)
 	struct lvm_state *lvm = llt->lvm;
 
 	if (lvm) {
-		if (lvm->dirty) {
-			lua_modules_free(task, lvm->L);
-			lvm_vm_reset(lvm);
-			lvm->dirty = false;
+		if (!READ_ONCE(lvm->L)) {
+			kfree(lvm);
+		} else {
+			if (lvm->dirty) {
+				lua_modules_free(task, lvm->L);
+				lvm_vm_reset(lvm);
+				lvm->dirty = false;
+			}
+			refcount_init(&lvm->refcount, 0);
+			lvm_pool_put(lvm);
 		}
-		refcount_init(&lvm->refcount, 0);
-		lvm_pool_put(lvm);
 		llt->lvm = NULL;
 	}
 	kvcache_dict_free(&llt->dict);

--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -1141,12 +1141,18 @@ static int lvm_remove_module(lua_State *L, struct lua_lsm_module *module)
 
 static int task_remove_module(struct task_struct *task, void *arg)
 {
+	struct lua_lsm_task *llt = lua_lsm_task(task);
+	struct lvm_state *lvm = llt->lvm;
 	struct lua_lsm_module *module = arg;
 	lua_State *L;
 	int err;
 
 	if (task_curr(task) && task != current)
 		return -EBUSY;
+
+	/* Unregister must not lazily create a VM for untouched tasks. */
+	if (!lvm || !smp_load_acquire(&lvm->L))
+		return -ENOENT;
 
 	L = lvm_get_from_task(task, true);
 	if (!L)
@@ -1181,10 +1187,9 @@ static int tasks_lvm_remove_module(struct lua_lsm_module *module, int *nbusy)
 			__log_info("<%s>: err = %s \t<%s>: %d-%d\n",
 				   module->name, err == -EBUSY ? "EBUSY" : "EAGAIN",
 				   task->comm, task_tgid_nr(task), task_pid_nr(task));
-		} else {
-			__log_info_ratelimited("<%s>: err = %s \t<%s>: %d-%d\n",
-					       module->name,
-					       err == -ENOENT ? "[ENOENT]" : "unknown",
+		} else if (err != -ENOENT) {
+			__log_info_ratelimited("<%s>: err = %d \t<%s>: %d-%d\n",
+					       module->name, err,
 					       task->comm, task_tgid_nr(task), task_pid_nr(task));
 		}
 	}

--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -436,16 +436,26 @@ static void lvm_mark_dirty(lua_State *L)
 }
 
 static lua_State *
-lvm_get_from_task(const struct task_struct *task, bool exclusive)
+lvm_get_from_task(const struct task_struct *task, bool require_idle)
 {
 	struct lua_lsm_task *llt = lua_lsm_task(task);
 	struct lvm_state *lvm = llt->lvm;
 	lua_State *L;
 	int n;
 
-	/* Pairs with cmpxchg_release() that publishes a built lua_State. */
+	n = refcount_acquire(&lvm->refcount);
+	if (require_idle && n != 1) {
+		refcount_release(&lvm->refcount);
+		return NULL;
+	}
+	if (!require_idle) {
+		WARN_ON(n != 1);
+		KASSERT(n == 1, ("<%s> Lua VM is reused, refcount = %d\n",
+				 task->comm, n));
+	}
+
 	L = smp_load_acquire(&lvm->L);
-	if (unlikely(!L)) {
+	if (!L) {
 		struct lvm_state *pooled = lvm_pool_get();
 		struct lvm_state build_owner;
 		struct lvm_state *owner;
@@ -459,40 +469,29 @@ lvm_get_from_task(const struct task_struct *task, bool exclusive)
 			memset(&build_owner, 0, sizeof(build_owner));
 			built = lvm_build_lua_state(&build_owner);
 			if (!built)
-				return NULL;
+				goto err_put;
 			owner = &build_owner;
 		}
-		if (cmpxchg_release(&lvm->L, NULL, built) != NULL) {
-			lua_close(built);
-			lvm_stats_vmfree();
-			kfree(pooled);
-		} else {
-			lua_setallocf(built, lvm_alloc, lvm);
+		lua_setallocf(built, lvm_alloc, lvm);
 #ifdef CONFIG_SECURITY_LUA_LSM_STATS
-			atomic64_set(&lvm->nalloc,
-				atomic64_read(&owner->nalloc));
-			atomic64_set(&lvm->nrealloc,
-				atomic64_read(&owner->nrealloc));
-			atomic64_set(&lvm->nfree,
-				atomic64_read(&owner->nfree));
+		atomic64_set(&lvm->nalloc, atomic64_read(&owner->nalloc));
+		atomic64_set(&lvm->nrealloc,
+			     atomic64_read(&owner->nrealloc));
+		atomic64_set(&lvm->nfree, atomic64_read(&owner->nfree));
 #endif
-			kfree(pooled);
-		}
-		/* Pairs with cmpxchg_release() above. */
-		L = smp_load_acquire(&lvm->L);
-		if (WARN_ON_ONCE(!L))
-			return NULL;
+		kfree(pooled);
+		/*
+		 * Readers treat non-NULL lvm->L as a ready VM, so publish it
+		 * only after the allocator owner has moved to the task lvm.
+		 */
+		smp_store_release(&lvm->L, built);
+		L = built;
 	}
-
-	n = refcount_acquire(&lvm->refcount);
-	if (exclusive && n != 1) {
-		refcount_release(&lvm->refcount);
-		return NULL;
-	}
-	WARN_ON(n != 1);
-	KASSERT(n == 1, ("<%s> Lua VM is reused, refcount = %d\n",
-			 task->comm, n));
 	return L;
+
+err_put:
+	refcount_release(&lvm->refcount);
+	return NULL;
 }
 
 static void lvm_put_to_task(const struct task_struct *task, lua_State *L)

--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -51,6 +51,8 @@ struct list_head lsm_modules = LIST_HEAD_INIT(lsm_modules);
 static DEFINE_MUTEX(modules_mutex);
 DEFINE_SRCU(modules_ss);
 
+DEFINE_STATIC_KEY_FALSE(lua_lsm_modules_active);
+
 struct lua_lsm_hook_stat lua_lsm_hook_stats[] = {
 	#define LSM_HOOK(RET, DEFAULT, NAME, ...)			\
 		{ .name = #NAME, .nhooks = ATOMIC_INIT(0), },
@@ -1033,6 +1035,7 @@ int lua_lsm_module_register(const char *code, size_t len)
 
 		module->state = LMS_STATE_LIVE;
 		list_add_tail_rcu(&module->list, &lsm_modules);
+		static_branch_inc(&lua_lsm_modules_active);
 	}
 	mutex_unlock(&modules_mutex);
 
@@ -1182,6 +1185,7 @@ int lua_lsm_module_unregister(const char *name)
 	}
 	if (found && module->state == LMS_STATE_LIVE) {
 		module->state = LMS_STATE_GOING;
+		static_branch_dec(&lua_lsm_modules_active);
 
 		for (i = 0; lua_lsm_hook_stats[i].name; i++) {
 			if (__BITMAP_ISSET(i, &module->hookfuncs))

--- a/security/lua/lsm.h
+++ b/security/lua/lsm.h
@@ -56,6 +56,9 @@ static inline bool lua_lsm_hook_supported(unsigned int nr)
 	case __LL_NR_getprocattr:
 	case __LL_NR_setprocattr:
 	case __LL_NR_lsmprop_to_secctx:
+#ifdef CONFIG_SECURITY_NETWORK_XFRM
+	case __LL_NR_xfrm_state_pol_flow_match:
+#endif
 		return false;
 	default:
 		return nr < __LL_NR_MAX;

--- a/security/lua/lsm.h
+++ b/security/lua/lsm.h
@@ -17,9 +17,12 @@
 #include <linux/spinlock.h>
 #include <linux/perf_event.h>
 #include <linux/u64_stats_sync.h>
+#include <linux/jump_label.h>
 #include <linux/lua.h>
 #include "bitmap.h"
 #include "kvcache.h"
+
+DECLARE_STATIC_KEY_FALSE(lua_lsm_modules_active);
 
 /* Flag indicating whether initialization completed */
 extern int lua_lsm_initialized __initdata;

--- a/security/lua/lsm_defs.c
+++ b/security/lua/lsm_defs.c
@@ -1154,7 +1154,7 @@ LUA_LSM_INT_DEFINE1(inode_getattr, const struct path *, path)
  * inode_xattr_skipcap
  * Default: 0
  */
-LUA_LSM_INT_DEFINE1(inode_xattr_skipcap, const char *, name)
+LUA_LSM_INT_BOOL_DEFINE1(inode_xattr_skipcap, const char *, name)
 {
 	lua_pushstring(L, name);
 }
@@ -1318,7 +1318,7 @@ LUA_LSM_VOID_DEFINE3(inode_post_remove_acl, struct mnt_idmap *, idmap,
  * inode_need_killpriv
  * Default: 0
  */
-LUA_LSM_INT_DEFINE1(inode_need_killpriv, struct dentry *, dentry)
+LUA_LSM_INT_BOOLERR_DEFINE1(inode_need_killpriv, struct dentry *, dentry)
 {
 	*newdentry(L) = dentry;
 }
@@ -2560,7 +2560,7 @@ LUA_LSM_INT_DEFINE3(setprocattr, const char *, name,
  * ismaclabel
  * Default: 0
  */
-LUA_LSM_INT_DEFINE1(ismaclabel, const char *, name)
+LUA_LSM_INT_BOOL_DEFINE1(ismaclabel, const char *, name)
 {
 	lua_pushstring(L, name);
 }
@@ -3301,8 +3301,9 @@ LUA_LSM_INT_DEFINE2(xfrm_policy_lookup, struct xfrm_sec_ctx *, ctx,
  * TODO: xfrm_state_pol_flow_match
  * Default: 1
  */
-LUA_LSM_INT_DEFINE3(xfrm_state_pol_flow_match, struct xfrm_state *, x,
-		struct xfrm_policy *, xp, const struct flowi_common *, flic)
+LUA_LSM_INT_BOOL_DEFINE3(xfrm_state_pol_flow_match, struct xfrm_state *, x,
+			 struct xfrm_policy *, xp,
+			 const struct flowi_common *, flic)
 {
 	lua_pushnil(L);	/* TODO: x */
 	lua_pushnil(L);	/* TODO: xp */
@@ -3396,7 +3397,7 @@ LUA_LSM_INT_DEFINE5(audit_rule_init, u32, field, u32, op, char *, rulestr,
  * TODO: audit_rule_known
  * Default: 0
  */
-LUA_LSM_INT_DEFINE1(audit_rule_known, struct audit_krule *, krule)
+LUA_LSM_INT_BOOL_DEFINE1(audit_rule_known, struct audit_krule *, krule)
 {
 	lua_pushnil(L);	/* TODO: krule */
 }
@@ -3405,8 +3406,8 @@ LUA_LSM_INT_DEFINE1(audit_rule_known, struct audit_krule *, krule)
  * TODO: audit_rule_match
  * Default: 0
  */
-LUA_LSM_INT_DEFINE4(audit_rule_match, struct lsm_prop *, prop, u32, field,
-		u32, op, void *, lsmrule)
+LUA_LSM_INT_BOOLERR_DEFINE4(audit_rule_match, struct lsm_prop *, prop,
+			    u32, field, u32, op, void *, lsmrule)
 {
 	lua_pushnil(L);	/* TODO: prop */
 	lua_pushinteger(L, (lua_Integer)field);

--- a/security/lua/lsm_defs.h
+++ b/security/lua/lsm_defs.h
@@ -131,6 +131,8 @@
 		if (atomic_read(&lua_lsm_hook_stats[__LL_NR_ ## NAME].nhooks) == 0)	\
 			return ret;							\
 		L = lvm_get();								\
+		if (WARN_ON_ONCE(!L))							\
+			return -ENOMEM;							\
 		lua_pushcfunction(L, lua_traceback);					\
 		lua_pushthread(L);							\
 		lua_getfenv(L, -1);			/* save thread.fenv */		\

--- a/security/lua/lsm_defs.h
+++ b/security/lua/lsm_defs.h
@@ -53,10 +53,34 @@
 #define DECL_ARGS_5
 #define DECL_ARGS_6
 
+#define DECL_RETP_ARGS_0	int *retp
+#define DECL_RETP_ARGS_1	int *retp,
+#define DECL_RETP_ARGS_2	int *retp,
+#define DECL_RETP_ARGS_3	int *retp,
+#define DECL_RETP_ARGS_4	int *retp,
+#define DECL_RETP_ARGS_5	int *retp,
+#define DECL_RETP_ARGS_6	int *retp,
+
+#define CALL_RETP_ARGS_0	(&ret)
+#define CALL_RETP_ARGS_1	(&ret),
+#define CALL_RETP_ARGS_2	(&ret),
+#define CALL_RETP_ARGS_3	(&ret),
+#define CALL_RETP_ARGS_4	(&ret),
+#define CALL_RETP_ARGS_5	(&ret),
+#define CALL_RETP_ARGS_6	(&ret),
+
 #define ASSIGN_FROM_FUNC_void(ret)
 #define ASSIGN_FROM_FUNC_int(ret)	ret =
 
 #define PCALL_RES_void(L, top, ret)	do {} while (0)
+
+static inline void lua_lsm_pcall_res_errno(lua_State *L, int idx, int *retp)
+{
+	int errnum = lua_tointeger(L, idx);
+
+	if (errnum > 0 && errnum <= MAX_ERRNO)
+		*retp = -errnum;
+}
 
 /*
  * hooks result format:
@@ -67,30 +91,71 @@
  *   false, errno : -errno
  *   nil, errno   : -errno
  */
-#define PCALL_RES_int(L, top, ret)							\
-	do {										\
-		/* stack: [..., _M, res1, ...] */					\
-		int nres = lua_gettop(L) - top + 1;					\
-		switch (nres) {								\
-		case 0:									\
-			break;								\
-		case 1:									\
-			if (lua_type(L, top) == LUA_TBOOLEAN)				\
-				ret = lua_toboolean(L, top) ? 0 : -EPERM;		\
-			break;								\
-		default:								\
-			if (!lua_toboolean(L, top)) {					\
-				int errno = lua_tointeger(L, top + 1);			\
-				if (errno > 0 && errno <= MAX_ERRNO)			\
-					ret = -errno;					\
-			}								\
-			break;								\
-		}									\
-		lua_pop(L, nres);							\
-	} while (0)
+static inline void lua_lsm_pcall_res_int(lua_State *L, int top, int *retp)
+{
+	int nres = lua_gettop(L) - top + 1;
+
+	/* stack: [..., _M, res1, ...] */
+	switch (nres) {
+	case 0:
+		break;
+	case 1:
+		if (lua_type(L, top) == LUA_TBOOLEAN)
+			*retp = lua_toboolean(L, top) ? 0 : -EPERM;
+		break;
+	default:
+		if (!lua_toboolean(L, top))
+			lua_lsm_pcall_res_errno(L, top + 1, retp);
+		break;
+	}
+	lua_pop(L, nres);
+}
+
+static inline void lua_lsm_pcall_res_bool(lua_State *L, int top, int *retp)
+{
+	int nres = lua_gettop(L) - top + 1;
+
+	if (nres > 0 && lua_type(L, top) == LUA_TBOOLEAN)
+		*retp = lua_toboolean(L, top) ? 1 : 0;
+	lua_pop(L, nres);
+}
+
+static inline void lua_lsm_pcall_res_boolerr(lua_State *L, int top, int *retp)
+{
+	int nres = lua_gettop(L) - top + 1;
+	int tt;
+
+	switch (nres) {
+	case 0:
+		break;
+	case 1:
+		tt = lua_type(L, top);
+		if (tt == LUA_TBOOLEAN)
+			*retp = lua_toboolean(L, top) ? 1 : 0;
+		break;
+	default:
+		tt = lua_type(L, top);
+		if (tt == LUA_TBOOLEAN) {
+			if (lua_toboolean(L, top))
+				*retp = 1;
+			else
+				lua_lsm_pcall_res_errno(L, top + 1, retp);
+		} else if (tt == LUA_TNIL) {
+			lua_lsm_pcall_res_errno(L, top + 1, retp);
+		}
+		break;
+	}
+	lua_pop(L, nres);
+}
+
+#define PCALL_RES_int(L, top, ret)	lua_lsm_pcall_res_int(L, top, &(ret))
+#define PCALL_RES_bool(L, top, ret)	lua_lsm_pcall_res_bool(L, top, &(ret))
+#define PCALL_RES_boolerr(L, top, ret)	lua_lsm_pcall_res_boolerr(L, top, &(ret))
 
 #define LCALL_NRES_void		0
 #define LCALL_NRES_int		LUA_MULTRET
+#define LCALL_NRES_bool		LUA_MULTRET
+#define LCALL_NRES_boolerr	LUA_MULTRET
 
 #define LUA_PCALL(rettype, L, top, ret)							\
 	do {										\
@@ -115,21 +180,38 @@
 #define RET_CHECK_void(NAME, ret)	do {} while (0)
 
 #define RET_CHECK_int(NAME, ret)							\
-	if ((ret) && (ret) != LSM_RET_DEFAULT(NAME))					\
+	if ((ret) != LSM_RET_DEFAULT(NAME))						\
 		break
 
+#define RET_CHECK_bool(NAME, ret)	RET_CHECK_int(NAME, ret)
+#define RET_CHECK_boolerr(NAME, ret)	RET_CHECK_int(NAME, ret)
 
-#define LUA_LSM_DEFINEx(x, NAME, rettype, vmtype, ...)					\
+static inline int lua_lsm_dispatch_failret_default(int default_ret)
+{
+	return default_ret;
+}
+
+static inline int lua_lsm_dispatch_failret_errno(int default_ret __maybe_unused)
+{
+	return -ENOMEM;
+}
+
+#define LUA_LSM_DISPATCH_FAILRET_DEFAULT(NAME)			\
+	lua_lsm_dispatch_failret_default(LSM_RET_DEFAULT(NAME))
+#define LUA_LSM_DISPATCH_FAILRET_ERRNO(NAME)			\
+	lua_lsm_dispatch_failret_errno(LSM_RET_DEFAULT(NAME))
+
+#define LUA_LSM_DEFINEx(x, NAME, rettype, vmtype, pcalltype, failret, ...)		\
 	static inline vmtype __lua_lsm_vm_ ## NAME(lua_State *L	__VA_OPT__(,)		\
 					__MAP(x, __SC_DECL, __VA_ARGS__));		\
-	static inline int __lua_lsm_ ## NAME(DECL_ARGS_ ## x				\
+	static inline int __lua_lsm_ ## NAME(DECL_RETP_ARGS_ ## x		\
 					__MAP(x, __SC_DECL, __VA_ARGS__))		\
 	{										\
 		struct lua_lsm_module *module;						\
 		lua_State *L;								\
 		int ret = LSM_RET_DEFAULT(NAME);					\
 		if (atomic_read(&lua_lsm_hook_stats[__LL_NR_ ## NAME].nhooks) == 0)	\
-			return ret;							\
+			goto out;							\
 		L = lvm_get();								\
 		if (WARN_ON_ONCE(!L))							\
 			return -ENOMEM;							\
@@ -157,18 +239,20 @@
 				ASSIGN_FROM_FUNC_ ## vmtype(ret)			\
 					__lua_lsm_vm_ ## NAME(L __VA_OPT__(,)		\
 						__MAP(x, __SC_ARGS, __VA_ARGS__));	\
-				END_VM_CALL_ ## vmtype(rettype, L, top, ret);		\
+				END_VM_CALL_ ## vmtype(pcalltype, L, top, ret);		\
 			} else {							\
 				lua_pop(L, 1);		/* pop lfunc */			\
 			}								\
 			lua_pop(L, 1);			/* pop _M */			\
-			RET_CHECK_ ## rettype(NAME, ret);				\
+			RET_CHECK_ ## pcalltype(NAME, ret);				\
 		}									\
 		lua_pushnil(L);								\
 		lua_setfield(L, LUA_REGISTRYINDEX, CURR_ENV);				\
 		lua_pop(L, 4);								\
 		lvm_put(L);								\
-		return ret;								\
+out:											\
+		*retp = ret;								\
+		return 0;								\
 	}										\
 	rettype lua_lsm_ ## NAME(DECL_ARGS_ ## x					\
 				__MAP(x, __SC_DECL, __VA_ARGS__))			\
@@ -179,10 +263,14 @@
 		ret = __prepare_ ## NAME(__MAP(x, __SC_ARGS, __VA_ARGS__));		\
 		if (ret >= 0) {								\
 			int idx = srcu_read_lock(&modules_ss);				\
-			if (static_branch_unlikely(&lua_lsm_modules_active))		\
-				ret = __lua_lsm_ ## NAME(__MAP(x, __SC_ARGS, __VA_ARGS__));\
-			else								\
+			if (static_branch_unlikely(&lua_lsm_modules_active)) {		\
+				int err = __lua_lsm_ ## NAME(CALL_RETP_ARGS_ ## x	\
+					__MAP(x, __SC_ARGS, __VA_ARGS__));		\
+				if (err)						\
+					ret = LUA_LSM_DISPATCH_FAILRET_ ## failret(NAME);\
+			} else {							\
 				ret = LSM_RET_DEFAULT(NAME);				\
+			}								\
 			__postpone_ ## NAME(__MAP(x, __SC_ARGS, __VA_ARGS__));		\
 			srcu_read_unlock(&modules_ss, idx);				\
 		}									\
@@ -194,37 +282,95 @@
 
 /*****************************************************************************/
 
-#define LUA_LSM_VOID_DEFINE0(name, ...)		LUA_LSM_DEFINEx(0, name, void, void, ##__VA_ARGS__)
-#define LUA_LSM_VOID_DEFINE1(name, ...)		LUA_LSM_DEFINEx(1, name, void, void, ##__VA_ARGS__)
-#define LUA_LSM_VOID_DEFINE2(name, ...)		LUA_LSM_DEFINEx(2, name, void, void, ##__VA_ARGS__)
-#define LUA_LSM_VOID_DEFINE3(name, ...)		LUA_LSM_DEFINEx(3, name, void, void, ##__VA_ARGS__)
-#define LUA_LSM_VOID_DEFINE4(name, ...)		LUA_LSM_DEFINEx(4, name, void, void, ##__VA_ARGS__)
-#define LUA_LSM_VOID_DEFINE5(name, ...)		LUA_LSM_DEFINEx(5, name, void, void, ##__VA_ARGS__)
-#define LUA_LSM_VOID_DEFINE6(name, ...)		LUA_LSM_DEFINEx(6, name, void, void, ##__VA_ARGS__)
+#define LUA_LSM_VOID_DEFINE0(name, ...)					\
+	LUA_LSM_DEFINEx(0, name, void, void, void, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_VOID_DEFINE1(name, ...)					\
+	LUA_LSM_DEFINEx(1, name, void, void, void, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_VOID_DEFINE2(name, ...)					\
+	LUA_LSM_DEFINEx(2, name, void, void, void, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_VOID_DEFINE3(name, ...)					\
+	LUA_LSM_DEFINEx(3, name, void, void, void, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_VOID_DEFINE4(name, ...)					\
+	LUA_LSM_DEFINEx(4, name, void, void, void, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_VOID_DEFINE5(name, ...)					\
+	LUA_LSM_DEFINEx(5, name, void, void, void, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_VOID_DEFINE6(name, ...)					\
+	LUA_LSM_DEFINEx(6, name, void, void, void, DEFAULT, ##__VA_ARGS__)
 
-#define LUA_LSM_VOID_NAKED_DEFINE0(name, ...)	LUA_LSM_DEFINEx(0, name, void, int, ##__VA_ARGS__)
-#define LUA_LSM_VOID_NAKED_DEFINE1(name, ...)	LUA_LSM_DEFINEx(1, name, void, int, ##__VA_ARGS__)
-#define LUA_LSM_VOID_NAKED_DEFINE2(name, ...)	LUA_LSM_DEFINEx(2, name, void, int, ##__VA_ARGS__)
-#define LUA_LSM_VOID_NAKED_DEFINE3(name, ...)	LUA_LSM_DEFINEx(3, name, void, int, ##__VA_ARGS__)
-#define LUA_LSM_VOID_NAKED_DEFINE4(name, ...)	LUA_LSM_DEFINEx(4, name, void, int, ##__VA_ARGS__)
-#define LUA_LSM_VOID_NAKED_DEFINE5(name, ...)	LUA_LSM_DEFINEx(5, name, void, int, ##__VA_ARGS__)
-#define LUA_LSM_VOID_NAKED_DEFINE6(name, ...)	LUA_LSM_DEFINEx(6, name, void, int, ##__VA_ARGS__)
+#define LUA_LSM_VOID_NAKED_DEFINE0(name, ...)				\
+	LUA_LSM_DEFINEx(0, name, void, int, int, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_VOID_NAKED_DEFINE1(name, ...)				\
+	LUA_LSM_DEFINEx(1, name, void, int, int, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_VOID_NAKED_DEFINE2(name, ...)				\
+	LUA_LSM_DEFINEx(2, name, void, int, int, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_VOID_NAKED_DEFINE3(name, ...)				\
+	LUA_LSM_DEFINEx(3, name, void, int, int, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_VOID_NAKED_DEFINE4(name, ...)				\
+	LUA_LSM_DEFINEx(4, name, void, int, int, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_VOID_NAKED_DEFINE5(name, ...)				\
+	LUA_LSM_DEFINEx(5, name, void, int, int, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_VOID_NAKED_DEFINE6(name, ...)				\
+	LUA_LSM_DEFINEx(6, name, void, int, int, DEFAULT, ##__VA_ARGS__)
 
-#define LUA_LSM_INT_DEFINE0(name, ...)		LUA_LSM_DEFINEx(0, name, int, void, ##__VA_ARGS__)
-#define LUA_LSM_INT_DEFINE1(name, ...)		LUA_LSM_DEFINEx(1, name, int, void, ##__VA_ARGS__)
-#define LUA_LSM_INT_DEFINE2(name, ...)		LUA_LSM_DEFINEx(2, name, int, void, ##__VA_ARGS__)
-#define LUA_LSM_INT_DEFINE3(name, ...)		LUA_LSM_DEFINEx(3, name, int, void, ##__VA_ARGS__)
-#define LUA_LSM_INT_DEFINE4(name, ...)		LUA_LSM_DEFINEx(4, name, int, void, ##__VA_ARGS__)
-#define LUA_LSM_INT_DEFINE5(name, ...)		LUA_LSM_DEFINEx(5, name, int, void, ##__VA_ARGS__)
-#define LUA_LSM_INT_DEFINE6(name, ...)		LUA_LSM_DEFINEx(6, name, int, void, ##__VA_ARGS__)
+#define LUA_LSM_INT_DEFINE0(name, ...)					\
+	LUA_LSM_DEFINEx(0, name, int, void, int, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_DEFINE1(name, ...)					\
+	LUA_LSM_DEFINEx(1, name, int, void, int, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_DEFINE2(name, ...)					\
+	LUA_LSM_DEFINEx(2, name, int, void, int, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_DEFINE3(name, ...)					\
+	LUA_LSM_DEFINEx(3, name, int, void, int, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_DEFINE4(name, ...)					\
+	LUA_LSM_DEFINEx(4, name, int, void, int, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_DEFINE5(name, ...)					\
+	LUA_LSM_DEFINEx(5, name, int, void, int, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_DEFINE6(name, ...)					\
+	LUA_LSM_DEFINEx(6, name, int, void, int, ERRNO, ##__VA_ARGS__)
 
-#define LUA_LSM_INT_NAKED_DEFINE0(name, ...)	LUA_LSM_DEFINEx(0, name, int, int, ##__VA_ARGS__)
-#define LUA_LSM_INT_NAKED_DEFINE1(name, ...)	LUA_LSM_DEFINEx(1, name, int, int, ##__VA_ARGS__)
-#define LUA_LSM_INT_NAKED_DEFINE2(name, ...)	LUA_LSM_DEFINEx(2, name, int, int, ##__VA_ARGS__)
-#define LUA_LSM_INT_NAKED_DEFINE3(name, ...)	LUA_LSM_DEFINEx(3, name, int, int, ##__VA_ARGS__)
-#define LUA_LSM_INT_NAKED_DEFINE4(name, ...)	LUA_LSM_DEFINEx(4, name, int, int, ##__VA_ARGS__)
-#define LUA_LSM_INT_NAKED_DEFINE5(name, ...)	LUA_LSM_DEFINEx(5, name, int, int, ##__VA_ARGS__)
-#define LUA_LSM_INT_NAKED_DEFINE6(name, ...)	LUA_LSM_DEFINEx(6, name, int, int, ##__VA_ARGS__)
+#define LUA_LSM_INT_BOOL_DEFINE0(name, ...)				\
+	LUA_LSM_DEFINEx(0, name, int, void, bool, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_INT_BOOL_DEFINE1(name, ...)				\
+	LUA_LSM_DEFINEx(1, name, int, void, bool, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_INT_BOOL_DEFINE2(name, ...)				\
+	LUA_LSM_DEFINEx(2, name, int, void, bool, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_INT_BOOL_DEFINE3(name, ...)				\
+	LUA_LSM_DEFINEx(3, name, int, void, bool, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_INT_BOOL_DEFINE4(name, ...)				\
+	LUA_LSM_DEFINEx(4, name, int, void, bool, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_INT_BOOL_DEFINE5(name, ...)				\
+	LUA_LSM_DEFINEx(5, name, int, void, bool, DEFAULT, ##__VA_ARGS__)
+#define LUA_LSM_INT_BOOL_DEFINE6(name, ...)				\
+	LUA_LSM_DEFINEx(6, name, int, void, bool, DEFAULT, ##__VA_ARGS__)
+
+#define LUA_LSM_INT_BOOLERR_DEFINE0(name, ...)				\
+	LUA_LSM_DEFINEx(0, name, int, void, boolerr, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_BOOLERR_DEFINE1(name, ...)				\
+	LUA_LSM_DEFINEx(1, name, int, void, boolerr, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_BOOLERR_DEFINE2(name, ...)				\
+	LUA_LSM_DEFINEx(2, name, int, void, boolerr, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_BOOLERR_DEFINE3(name, ...)				\
+	LUA_LSM_DEFINEx(3, name, int, void, boolerr, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_BOOLERR_DEFINE4(name, ...)				\
+	LUA_LSM_DEFINEx(4, name, int, void, boolerr, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_BOOLERR_DEFINE5(name, ...)				\
+	LUA_LSM_DEFINEx(5, name, int, void, boolerr, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_BOOLERR_DEFINE6(name, ...)				\
+	LUA_LSM_DEFINEx(6, name, int, void, boolerr, ERRNO, ##__VA_ARGS__)
+
+#define LUA_LSM_INT_NAKED_DEFINE0(name, ...)				\
+	LUA_LSM_DEFINEx(0, name, int, int, int, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_NAKED_DEFINE1(name, ...)				\
+	LUA_LSM_DEFINEx(1, name, int, int, int, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_NAKED_DEFINE2(name, ...)				\
+	LUA_LSM_DEFINEx(2, name, int, int, int, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_NAKED_DEFINE3(name, ...)				\
+	LUA_LSM_DEFINEx(3, name, int, int, int, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_NAKED_DEFINE4(name, ...)				\
+	LUA_LSM_DEFINEx(4, name, int, int, int, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_NAKED_DEFINE5(name, ...)				\
+	LUA_LSM_DEFINEx(5, name, int, int, int, ERRNO, ##__VA_ARGS__)
+#define LUA_LSM_INT_NAKED_DEFINE6(name, ...)				\
+	LUA_LSM_DEFINEx(6, name, int, int, int, ERRNO, ##__VA_ARGS__)
 
 
 /* prepare and postpone function macro */

--- a/security/lua/lsm_defs.h
+++ b/security/lua/lsm_defs.h
@@ -171,17 +171,19 @@
 	rettype lua_lsm_ ## NAME(DECL_ARGS_ ## x					\
 				__MAP(x, __SC_DECL, __VA_ARGS__))			\
 	{										\
-		int idx;								\
 		int ret;								\
 		DECLARE_STATS_VARS();							\
 		START_STATS(NAME);							\
-		idx = srcu_read_lock(&modules_ss);					\
 		ret = __prepare_ ## NAME(__MAP(x, __SC_ARGS, __VA_ARGS__));		\
 		if (ret >= 0) {								\
-			ret = __lua_lsm_ ## NAME(__MAP(x, __SC_ARGS, __VA_ARGS__));	\
+			int idx = srcu_read_lock(&modules_ss);				\
+			if (static_branch_unlikely(&lua_lsm_modules_active))		\
+				ret = __lua_lsm_ ## NAME(__MAP(x, __SC_ARGS, __VA_ARGS__));\
+			else								\
+				ret = LSM_RET_DEFAULT(NAME);				\
 			__postpone_ ## NAME(__MAP(x, __SC_ARGS, __VA_ARGS__));		\
+			srcu_read_unlock(&modules_ss, idx);				\
 		}									\
-		srcu_read_unlock(&modules_ss, idx);					\
 		END_STATS(NAME);							\
 		return (rettype)ret;							\
 	}										\


### PR DESCRIPTION
## Summary

Build per-task Lua VMs lazily and make the dispatch path safe when the
first VM construction happens inside an LSM hook.

The series avoids allocating a Lua VM for every task at task allocation
time.  Instead, each task gets the lightweight Lua-LSM task blob first,
and its Lua VM is created on the first hook dispatch that actually needs
one.  This reduces task allocation cost and avoids VM work when no Lua
module is active.

## Changes

- Skip Lua hook dispatch while no Lua modules are live.
- Create per-task Lua VMs lazily on first dispatch.
- Treat lazy VM allocation failure as a dispatcher failure, not as a Lua
  hook result.
- Avoid lazily creating untouched task VMs while unregistering a module.
- Hide `xfrm_state_pol_flow_match`, whose LSM default and dispatch
  semantics are not safe for Lua-LSM.
- Publish a newly built task VM only after its allocator owner and stats
  have moved to the target task VM state.

## Concurrency Notes

The first-use VM path now takes the task VM refcount before construction.
This makes "VM is being initialized" visible as a busy state to the
unregister path.

The new `lua_State` is published to `lvm->L` only after the allocator
userdata is moved from the temporary build owner to the target task
`struct lvm_state`.  This prevents unregister from observing a
half-initialized VM through `task_call_func()`.

The unregister path now either sees an untouched task VM, or fails the
idle-required VM get while the first hook dispatch owns the VM.

## Validation

```
git format-patch -1 --stdout HEAD | ./scripts/checkpatch.pl --strict -
make -s M=security/lua modules
make -s W=1 M=security/lua modules
```
