### PR TITLE
lua-lsm: reduce no-policy fast-path overhead

### DIFF
--- a/security/lua/kvcache.c
+++ b/security/lua/kvcache.c
@@ -6,6 +6,7 @@
  */
 
 #include "debug.h"
+#include <linux/bottom_half.h>
 #include <linux/slab.h>
 #include <linux/string.h>
 #include <linux/errname.h>
@@ -88,23 +89,38 @@ static int kvcache_dict_init_once(struct kvcache_dict *dict)
 	int state;
 
 	for (;;) {
+		local_bh_disable();
 		state = atomic_read_acquire(&dict->state);
 		if (likely(state == KVCACHE_DICT_READY))
-			return 0;
+			goto out_bh;
 		if (state == KVCACHE_DICT_INITING) {
+			local_bh_enable();
 			cpu_relax();
 			continue;
 		}
-		if (WARN_ON_ONCE(state != KVCACHE_DICT_UNINIT))
+		if (WARN_ON_ONCE(state != KVCACHE_DICT_UNINIT)) {
+			local_bh_enable();
 			return -EINVAL;
+		}
 
+		/*
+		 * Readers busy-wait while the dictionary is INITING. Keep the
+		 * UNINIT->READY transition within a softirq-disabled window so a
+		 * same-CPU softirq cannot observe INITING and spin before the
+		 * initializer publishes READY.
+		 */
 		if (atomic_try_cmpxchg(&dict->state, &state,
 				       KVCACHE_DICT_INITING)) {
 			__kvcache_dict_init(dict);
 			atomic_set_release(&dict->state, KVCACHE_DICT_READY);
-			return 0;
+			goto out_bh;
 		}
+		local_bh_enable();
 	}
+
+out_bh:
+	local_bh_enable();
+	return 0;
 }
 
 static int kvcache_result(lua_State *L, int err)

--- a/security/lua/kvcache.c
+++ b/security/lua/kvcache.c
@@ -10,6 +10,7 @@
 #include <linux/string.h>
 #include <linux/errname.h>
 #include <linux/rwlock.h>
+#include <linux/processor.h>
 #include <linux/lua.h>
 #include <linux/lualib.h>
 #include <linux/lauxlib.h>
@@ -59,6 +60,52 @@ static int kvcache_node_cmp(struct kvcache_node *n1, struct kvcache_node *n2)
 }
 
 RB_GENERATE_STATIC(kvcache, kvcache_node, node, kvcache_node_cmp);
+
+static void __kvcache_dict_init(struct kvcache_dict *dict)
+{
+	rwlock_init(&dict->lock);
+	RB_INIT(&dict->root);
+	atomic_set(&dict->count, 0);
+	dict->capacity = CACHE_CAPACITY;
+}
+
+static bool kvcache_dict_ready(struct kvcache_dict *dict)
+{
+	int state;
+
+	for (;;) {
+		state = atomic_read_acquire(&dict->state);
+		if (likely(state == KVCACHE_DICT_READY))
+			return true;
+		if (state != KVCACHE_DICT_INITING)
+			return false;
+		cpu_relax();
+	}
+}
+
+static int kvcache_dict_init_once(struct kvcache_dict *dict)
+{
+	int state;
+
+	for (;;) {
+		state = atomic_read_acquire(&dict->state);
+		if (likely(state == KVCACHE_DICT_READY))
+			return 0;
+		if (state == KVCACHE_DICT_INITING) {
+			cpu_relax();
+			continue;
+		}
+		if (WARN_ON_ONCE(state != KVCACHE_DICT_UNINIT))
+			return -EINVAL;
+
+		if (atomic_try_cmpxchg(&dict->state, &state,
+				       KVCACHE_DICT_INITING)) {
+			__kvcache_dict_init(dict);
+			atomic_set_release(&dict->state, KVCACHE_DICT_READY);
+			return 0;
+		}
+	}
+}
 
 static int kvcache_result(lua_State *L, int err)
 {
@@ -133,6 +180,9 @@ kvcache_lookup(struct kvcache_dict *dict,
 {
 	struct kvcache_node tmp, *node;
 	unsigned long flags;
+
+	if (!kvcache_dict_ready(dict))
+		return NULL;
 
 	tmp.key = key;
 	tmp.module = module;
@@ -269,6 +319,10 @@ static int kvcache_set(lua_State *L, struct kvcache_dict *dict,
 	struct kvcache_node *node, *prev;
 	int err;
 
+	err = kvcache_dict_init_once(dict);
+	if (err)
+		return kvcache_result(L, err);
+
 	node = kvcache_lookup(dict, module, key);
 	if (!node) {
 		if (tt == LUA_TNIL)
@@ -365,6 +419,10 @@ static int kvcache_incr(lua_State *L, struct kvcache_dict *dict,
 	unsigned long flags;
 	int err;
 
+	err = kvcache_dict_init_once(dict);
+	if (err)
+		return kvcache_result(L, err);
+
 	node = kvcache_lookup(dict, module, key);
 	if (!node) {
 		node = kvcache_node_alloc(dict, module, key, len);
@@ -450,6 +508,9 @@ void kvcache_dict_free(struct kvcache_dict *dict)
 	struct kvcache_node *node, *n;
 	struct lua_lsm_module *module;
 
+	if (!kvcache_dict_ready(dict))
+		return;
+
 	if (atomic_read(&dict->count) == 0)
 		return;
 
@@ -474,10 +535,9 @@ void kvcache_dict_free(struct kvcache_dict *dict)
 
 void kvcache_dict_init(struct kvcache_dict *dict)
 {
-	rwlock_init(&dict->lock);
-	RB_INIT(&dict->root);
-	atomic_set(&dict->count, 0);
-	dict->capacity = CACHE_CAPACITY;
+	atomic_set(&dict->state, KVCACHE_DICT_INITING);
+	__kvcache_dict_init(dict);
+	atomic_set_release(&dict->state, KVCACHE_DICT_READY);
 }
 
 /******************************** object cache *******************************/

--- a/security/lua/kvcache.h
+++ b/security/lua/kvcache.h
@@ -9,6 +9,7 @@
 #define _SECURITY_LUA_LSM_KVCACHE_H
 
 #include <linux/list.h>
+#include <linux/atomic.h>
 #include <linux/rwlock.h>
 #include <linux/seq_file.h>
 #include <linux/lua.h>
@@ -17,6 +18,12 @@
 #include "tree.h"
 
 #define CACHE_CAPACITY	1024
+
+enum kvcache_dict_state {
+	KVCACHE_DICT_UNINIT,
+	KVCACHE_DICT_INITING,
+	KVCACHE_DICT_READY,
+};
 
 struct lua_lsm_module;
 
@@ -37,6 +44,7 @@ struct kvcache_node {
 };
 
 struct kvcache_dict {
+	atomic_t state;
 	int capacity;
 	atomic_t count;
 	rwlock_t lock;

--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -435,15 +435,66 @@ static void lvm_mark_dirty(lua_State *L)
 	((struct lvm_state *)ud)->dirty = true;
 }
 
+static bool lvm_task_teardown(const struct lua_lsm_task *llt)
+{
+	/* Pairs with smp_store_release() in task_blob_free(). */
+	return smp_load_acquire(&llt->lvm_teardown);
+}
+
+bool lvm_current_task_teardown(void)
+{
+	return in_task() && lvm_task_teardown(lua_lsm_task(current));
+}
+
+static struct lvm_state *
+lvm_get_task_state(const struct task_struct *task, bool create)
+{
+	struct lua_lsm_task *llt = lua_lsm_task(task);
+	struct lvm_state *lvm, *old;
+
+	if (unlikely(lvm_task_teardown(llt)))
+		return NULL;
+
+	/* Pairs with cmpxchg() publishing a lazy task VM state. */
+	lvm = smp_load_acquire(&llt->lvm);
+	if (likely(lvm || !create))
+		return lvm;
+
+	lvm = kzalloc(sizeof(*lvm), lua_lsm_gfp());
+	if (!lvm)
+		return NULL;
+
+	if (unlikely(lvm_task_teardown(llt))) {
+		kfree(lvm);
+		return NULL;
+	}
+
+	old = cmpxchg(&llt->lvm, NULL, lvm);
+	if (old) {
+		kfree(lvm);
+		lvm = old;
+	}
+
+	if (unlikely(lvm_task_teardown(llt)))
+		return NULL;
+
+	return lvm;
+}
+
 static lua_State *
 lvm_get_from_task(const struct task_struct *task, bool require_idle)
 {
 	struct lua_lsm_task *llt = lua_lsm_task(task);
-	struct lvm_state *lvm = llt->lvm;
+	struct lvm_state *lvm = lvm_get_task_state(task, !require_idle);
 	lua_State *L;
 	int n;
 
+	if (!lvm)
+		return NULL;
+
 	n = refcount_acquire(&lvm->refcount);
+	if (unlikely(lvm_task_teardown(llt)))
+		goto err_put;
 	if (require_idle && n != 1) {
 		refcount_release(&lvm->refcount);
 		return NULL;
@@ -497,7 +548,7 @@ err_put:
 static void lvm_put_to_task(const struct task_struct *task, lua_State *L)
 {
 	struct lua_lsm_task *llt = lua_lsm_task(task);
-	struct lvm_state *lvm = llt->lvm;
+	struct lvm_state *lvm = READ_ONCE(llt->lvm);
 	int n = refcount_release(&lvm->refcount);
 
 	KASSERT(n == 0, ("<%s> Lua VM is reused, refcount = %d\n",
@@ -1141,8 +1192,8 @@ static int lvm_remove_module(lua_State *L, struct lua_lsm_module *module)
 static int task_remove_module(struct task_struct *task, void *arg)
 {
 	struct lua_lsm_task *llt = lua_lsm_task(task);
-	struct lvm_state *lvm = llt->lvm;
 	struct lua_lsm_module *module = arg;
+	struct lvm_state *lvm;
 	lua_State *L;
 	int err;
 
@@ -1150,6 +1201,8 @@ static int task_remove_module(struct task_struct *task, void *arg)
 		return -EBUSY;
 
 	/* Unregister must not lazily create a VM for untouched tasks. */
+	/* Pairs with cmpxchg() in lvm_get_task_state(). */
+	lvm = smp_load_acquire(&llt->lvm);
 	if (!lvm || !smp_load_acquire(&lvm->L))
 		return -ENOENT;
 
@@ -1381,36 +1434,39 @@ int modules_show(struct seq_file *m, void *v)
 int task_blob_init(struct task_struct *task)
 {
 	struct lua_lsm_task *llt = lua_lsm_task(task);
-	struct lvm_state *lvm;
 
+	WRITE_ONCE(llt->lvm_teardown, false);
 	kvcache_dict_init(&llt->dict);
-
-	lvm = kzalloc(sizeof(*lvm), GFP_KERNEL);
-	if (!lvm)
-		return -ENOMEM;
-
-	llt->lvm = lvm;
 	return 0;
 }
 
 void task_blob_free(struct task_struct *task)
 {
 	struct lua_lsm_task *llt = lua_lsm_task(task);
-	struct lvm_state *lvm = llt->lvm;
+	struct lvm_state *lvm;
 
+	/*
+	 * Lua GC can run finalizers which re-enter LSM hooks. Keep the task VM
+	 * published until reset completes, but make lvm_get() skip this task so
+	 * re-entrant hooks cannot allocate or reuse a VM during teardown.
+	 */
+	smp_store_release(&llt->lvm_teardown, true);
+	/* Pairs with cmpxchg() in lvm_get_task_state(). */
+	lvm = smp_load_acquire(&llt->lvm);
+	if (lvm && READ_ONCE(lvm->L) && lvm->dirty) {
+		lua_modules_free(task, lvm->L);
+		lvm_vm_reset(lvm);
+		lvm->dirty = false;
+	}
+
+	lvm = xchg(&llt->lvm, NULL);
 	if (lvm) {
 		if (!READ_ONCE(lvm->L)) {
 			kfree(lvm);
 		} else {
-			if (lvm->dirty) {
-				lua_modules_free(task, lvm->L);
-				lvm_vm_reset(lvm);
-				lvm->dirty = false;
-			}
 			refcount_init(&lvm->refcount, 0);
 			lvm_pool_put(lvm);
 		}
-		llt->lvm = NULL;
 	}
 	kvcache_dict_free(&llt->dict);
 }

--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -52,7 +52,7 @@ static DEFINE_MUTEX(modules_mutex);
 DEFINE_SRCU(modules_ss);
 
 DEFINE_STATIC_KEY_FALSE(lua_lsm_modules_active);
-DEFINE_STATIC_KEY_FALSE(lua_lsm_inactive_cleanup_possible);
+DEFINE_STATIC_KEY_FALSE(lua_lsm_inactive_cleanup_armed);
 
 struct lua_lsm_hook_stat lua_lsm_hook_stats[] = {
 	#define LSM_HOOK(RET, DEFAULT, NAME, ...)			\
@@ -1140,7 +1140,11 @@ int lua_lsm_module_register(const char *code, size_t len)
 
 		module->state = LMS_STATE_LIVE;
 		list_add_tail_rcu(&module->list, &lsm_modules);
-		static_branch_enable(&lua_lsm_inactive_cleanup_possible);
+		/*
+		 * Once any Lua policy has been loaded, inactive free-hook cleanup
+		 * must stay armed for objects that outlive later module unload.
+		 */
+		static_branch_enable(&lua_lsm_inactive_cleanup_armed);
 		static_branch_inc(&lua_lsm_modules_active);
 	}
 	mutex_unlock(&modules_mutex);

--- a/security/lua/lsm.c
+++ b/security/lua/lsm.c
@@ -52,6 +52,7 @@ static DEFINE_MUTEX(modules_mutex);
 DEFINE_SRCU(modules_ss);
 
 DEFINE_STATIC_KEY_FALSE(lua_lsm_modules_active);
+DEFINE_STATIC_KEY_FALSE(lua_lsm_inactive_cleanup_possible);
 
 struct lua_lsm_hook_stat lua_lsm_hook_stats[] = {
 	#define LSM_HOOK(RET, DEFAULT, NAME, ...)			\
@@ -1139,6 +1140,7 @@ int lua_lsm_module_register(const char *code, size_t len)
 
 		module->state = LMS_STATE_LIVE;
 		list_add_tail_rcu(&module->list, &lsm_modules);
+		static_branch_enable(&lua_lsm_inactive_cleanup_possible);
 		static_branch_inc(&lua_lsm_modules_active);
 	}
 	mutex_unlock(&modules_mutex);

--- a/security/lua/lsm.h
+++ b/security/lua/lsm.h
@@ -23,6 +23,7 @@
 #include "kvcache.h"
 
 DECLARE_STATIC_KEY_FALSE(lua_lsm_modules_active);
+DECLARE_STATIC_KEY_FALSE(lua_lsm_inactive_cleanup_possible);
 
 /* Flag indicating whether initialization completed */
 extern int lua_lsm_initialized __initdata;

--- a/security/lua/lsm.h
+++ b/security/lua/lsm.h
@@ -113,6 +113,7 @@ extern struct srcu_struct modules_ss;
 
 lua_State *lvm_get(void);
 void lvm_put(lua_State *L);
+bool lvm_current_task_teardown(void);
 
 int lua_lsm_module_register(const char *code, size_t len);
 int lua_lsm_module_unregister(const char *name);
@@ -141,6 +142,7 @@ struct lvm_state {
 
 struct lua_lsm_task {
 	struct lvm_state *lvm;
+	bool lvm_teardown;
 	struct kvcache_dict dict;
 };
 

--- a/security/lua/lsm.h
+++ b/security/lua/lsm.h
@@ -23,7 +23,7 @@
 #include "kvcache.h"
 
 DECLARE_STATIC_KEY_FALSE(lua_lsm_modules_active);
-DECLARE_STATIC_KEY_FALSE(lua_lsm_inactive_cleanup_possible);
+DECLARE_STATIC_KEY_FALSE(lua_lsm_inactive_cleanup_armed);
 
 /* Flag indicating whether initialization completed */
 extern int lua_lsm_initialized __initdata;

--- a/security/lua/lsm_defs.h
+++ b/security/lua/lsm_defs.h
@@ -231,7 +231,8 @@ static inline bool lua_lsm_hook_has_inactive_cleanup(unsigned int nr)
 
 #define LUA_LSM_INACTIVE_CLEANUP(x, NAME, ...)						\
 	do {										\
-		if (lua_lsm_hook_has_inactive_cleanup(__LL_NR_ ## NAME)) {		\
+		if (static_branch_unlikely(&lua_lsm_inactive_cleanup_possible) &&	\
+		    lua_lsm_hook_has_inactive_cleanup(__LL_NR_ ## NAME)) {		\
 			int idx = srcu_read_lock(&modules_ss);				\
 			__postpone_ ## NAME(__MAP(x, __SC_ARGS, __VA_ARGS__));		\
 			srcu_read_unlock(&modules_ss, idx);				\

--- a/security/lua/lsm_defs.h
+++ b/security/lua/lsm_defs.h
@@ -231,7 +231,7 @@ static inline bool lua_lsm_hook_has_inactive_cleanup(unsigned int nr)
 
 #define LUA_LSM_INACTIVE_CLEANUP(x, NAME, ...)						\
 	do {										\
-		if (static_branch_unlikely(&lua_lsm_inactive_cleanup_possible) &&	\
+		if (static_branch_unlikely(&lua_lsm_inactive_cleanup_armed) &&	\
 		    lua_lsm_hook_has_inactive_cleanup(__LL_NR_ ## NAME)) {		\
 			int idx = srcu_read_lock(&modules_ss);				\
 			__postpone_ ## NAME(__MAP(x, __SC_ARGS, __VA_ARGS__));		\

--- a/security/lua/lsm_defs.h
+++ b/security/lua/lsm_defs.h
@@ -201,16 +201,53 @@ static inline int lua_lsm_dispatch_failret_errno(int default_ret __maybe_unused)
 #define LUA_LSM_DISPATCH_FAILRET_ERRNO(NAME)			\
 	lua_lsm_dispatch_failret_errno(LSM_RET_DEFAULT(NAME))
 
+static inline bool lua_lsm_hook_active(unsigned int nr)
+{
+	return static_branch_unlikely(&lua_lsm_modules_active) &&
+	       atomic_read(&lua_lsm_hook_stats[nr].nhooks) != 0;
+}
+
+static inline bool lua_lsm_hook_has_inactive_cleanup(unsigned int nr)
+{
+	switch (nr) {
+	case __LL_NR_sb_free_security:
+	case __LL_NR_inode_free_security_rcu:
+	case __LL_NR_file_free_security:
+	case __LL_NR_task_free:
+	case __LL_NR_cred_free:
+	case __LL_NR_msg_msg_free_security:
+	case __LL_NR_msg_queue_free_security:
+	case __LL_NR_shm_free_security:
+	case __LL_NR_sem_free_security:
+#ifdef CONFIG_SECURITY_NETWORK
+	case __LL_NR_sk_free_security:
+#endif
+	case __LL_NR_bdev_free_security:
+		return true;
+	default:
+		return false;
+	}
+}
+
+#define LUA_LSM_INACTIVE_CLEANUP(x, NAME, ...)						\
+	do {										\
+		if (lua_lsm_hook_has_inactive_cleanup(__LL_NR_ ## NAME)) {		\
+			int idx = srcu_read_lock(&modules_ss);				\
+			__postpone_ ## NAME(__MAP(x, __SC_ARGS, __VA_ARGS__));		\
+			srcu_read_unlock(&modules_ss, idx);				\
+		}									\
+	} while (0)
+
 #define LUA_LSM_DEFINEx(x, NAME, rettype, vmtype, pcalltype, failret, ...)		\
 	static inline vmtype __lua_lsm_vm_ ## NAME(lua_State *L	__VA_OPT__(,)		\
 					__MAP(x, __SC_DECL, __VA_ARGS__));		\
-	static inline int __lua_lsm_ ## NAME(DECL_RETP_ARGS_ ## x		\
+	static inline int __lua_lsm_ ## NAME(DECL_RETP_ARGS_ ## x			\
 					__MAP(x, __SC_DECL, __VA_ARGS__))		\
 	{										\
 		struct lua_lsm_module *module;						\
 		lua_State *L;								\
 		int ret = LSM_RET_DEFAULT(NAME);					\
-		if (atomic_read(&lua_lsm_hook_stats[__LL_NR_ ## NAME].nhooks) == 0)	\
+		if (!lua_lsm_hook_active(__LL_NR_ ## NAME))				\
 			goto out;							\
 		L = lvm_get();								\
 		if (!L) {								\
@@ -262,6 +299,10 @@ out:											\
 	{										\
 		int ret;								\
 		DECLARE_STATS_VARS();							\
+		if (!lua_lsm_hook_active(__LL_NR_ ## NAME)) {				\
+			LUA_LSM_INACTIVE_CLEANUP(x, NAME, ##__VA_ARGS__);		\
+			return (rettype)LSM_RET_DEFAULT(NAME);				\
+		}									\
 		START_STATS(NAME);							\
 		ret = __prepare_ ## NAME(__MAP(x, __SC_ARGS, __VA_ARGS__));		\
 		if (ret >= 0) {								\

--- a/security/lua/lsm_defs.h
+++ b/security/lua/lsm_defs.h
@@ -213,8 +213,11 @@ static inline int lua_lsm_dispatch_failret_errno(int default_ret __maybe_unused)
 		if (atomic_read(&lua_lsm_hook_stats[__LL_NR_ ## NAME].nhooks) == 0)	\
 			goto out;							\
 		L = lvm_get();								\
-		if (WARN_ON_ONCE(!L))							\
+		if (!L) {								\
+			if (lvm_current_task_teardown())				\
+				goto out;						\
 			return -ENOMEM;							\
+		}									\
 		lua_pushcfunction(L, lua_traceback);					\
 		lua_pushthread(L);							\
 		lua_getfenv(L, -1);			/* save thread.fenv */		\


### PR DESCRIPTION
## Summary

Reduce the steady-state Lua-LSM overhead when no Lua policy is loaded.

The common no-policy path should avoid building per-task Lua VMs,
initializing per-object kvcache state, and entering the hook dispatch
machinery only to discover that no Lua handlers are active.

## Changes

- Allocate per-task Lua VM state only on first use.
- Initialize object kvcache dictionaries lazily.
- Skip inactive hook dispatch before entering SRCU and VM setup.
- Skip inactive cleanup before any Lua policy has been registered, while
  keeping free-hook cleanup enabled permanently after the first policy
  load so objects that outlive module unload still release Lua-LSM state.

## Validation

```sh
./scripts/checkpatch.pl --git origin/lua-lsm..lua-lsm-no-policy-fastpath
git diff --check origin/lua-lsm..lua-lsm-no-policy-fastpath
make -s M=security/lua modules
make -s W=1 M=security/lua modules
```
